### PR TITLE
More efficient select

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ user = await crud_users.get_multi(
 )
 ```
 
-To create, you pass a `CreateSchemaType` object with the attributes, such as a `CreateUser` pydantic schema:
+To create, you pass a `CreateSchemaType` object with the attributes, such as a `UserCreate` pydantic schema:
 ```python
 from app.core.schemas.user import UserCreate
 
@@ -606,14 +606,16 @@ crud_users.create(db=db, object=user_internal)
 
 To just check if there is at least one row that matches a certain set of attributes, you should use `exists`
 ```python
-# This queries only the email variable, and returns True if there's at least one or False if there is none
+# This queries only the email variable
+# It returns True if there's at least one or False if there is none
 crud_users.exists(db=db, email=user@example.com)
 ```
 
 To update you pass an `object` which may be a `pydantic schema` or just a regular `dict`, and the kwargs.
 You will update with `objects` the rows that match your `kwargs`.
 ```python
-# Here I'm updating the user with username == "myusername". I'll change his name to "Updated Name"
+# Here I'm updating the user with username == "myusername". 
+# #I'll change his name to "Updated Name"
 crud_users.update(db=db, object={name="Updated Name"}, username="myusername")
 ```
 
@@ -631,14 +633,15 @@ crud_users.delete(db=db, username="myusername")
 crud_users.db_delete(db=db, username="myusername")
 ```
 
-#### Advanced - Efficient Get
+#### More Efficient Selecting
 For the `get` and `get_multi` methods we have the option to define a `schema_to_select` attribute, which is what actually makes the queries more efficient. When you pass a pydantic schema in `schema_to_select` to the `get` or `get_multi` methods, only the attributes in the schema will be selected.
 ```python
 from app.schemas.user import UserRead
-# Here it's selecting all of the user's data, but maybe I just need what I'll return, the UserRead
+# Here it's selecting all of the user's data
 crud_user.get(db=db, username="myusername")
 
-# Now it's only selecting the data that is in UserRead. Since that's my response_model, it's all I need
+# Now it's only selecting the data that is in UserRead. 
+# Since that's my response_model, it's all I need
 crud_user.get(db=db, username="myusername", schema_to_select=UserRead)
 ```
 

--- a/README.md
+++ b/README.md
@@ -562,6 +562,16 @@ CRUDEntity = CRUDBase[Entity, EntityCreateInternal, EntityUpdate, EntityUpdateIn
 crud_entity = CRUDEntity(Entity)
 ```
 
+So, for users:
+```python
+# crud_users.py
+from app.model.user import User
+from app.schemas.user import UserCreateInternal, UserUpdate, UserUpdateInternal, UserDelete
+
+CRUDUser = CRUDBase[User, UserCreateInternal, UserUpdate, UserUpdateInternal, UserDelete]
+crud_users = CRUDUser(User)
+```
+
 When actually using the crud in an endpoint, to get data you just pass the database connection and the attributes as kwargs:
 ```python
 # Here I'm getting the users with email == user.email

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,32 +44,32 @@ services:
       - redis-data:/data
 
   # #-------- uncomment to create first superuser --------
-  # create_superuser:
-  #   build: 
-  #     context: .
-  #     dockerfile: Dockerfile
-  #   env_file:
-  #     - ./src/.env
-  #   depends_on:
-  #     - db
-  #   command: python -m src.scripts.create_first_superuser
-  #   volumes:
-  #     - ./src:/code/src
+  create_superuser:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - ./src/.env
+    depends_on:
+      - db
+    command: python -m src.scripts.create_first_superuser
+    volumes:
+      - ./src:/code/src
 
   # #-------- uncomment to run tests --------
-  # pytest:
-  #   build: 
-  #     context: .
-  #     dockerfile: Dockerfile 
-  #   env_file:
-  #     - ./src/.env 
-  #   depends_on:
-  #     - db
-  #     - create_superuser
-  #     - redis
-  #   command: python -m pytest
-  #   volumes:
-  #     - ./src:/code/src
+  pytest:
+    build: 
+      context: .
+      dockerfile: Dockerfile 
+    env_file:
+      - ./src/.env 
+    depends_on:
+      - db
+      - create_superuser
+      - redis
+    command: python -m pytest
+    volumes:
+      - ./src:/code/src
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,32 +44,32 @@ services:
       - redis-data:/data
 
   # #-------- uncomment to create first superuser --------
-  create_superuser:
-    build: 
-      context: .
-      dockerfile: Dockerfile
-    env_file:
-      - ./src/.env
-    depends_on:
-      - db
-    command: python -m src.scripts.create_first_superuser
-    volumes:
-      - ./src:/code/src
+  # create_superuser:
+  #   build: 
+  #     context: .
+  #     dockerfile: Dockerfile
+  #   env_file:
+  #     - ./src/.env
+  #   depends_on:
+  #     - db
+  #   command: python -m src.scripts.create_first_superuser
+  #   volumes:
+  #     - ./src:/code/src
 
   # #-------- uncomment to run tests --------
-  pytest:
-    build: 
-      context: .
-      dockerfile: Dockerfile 
-    env_file:
-      - ./src/.env 
-    depends_on:
-      - db
-      - create_superuser
-      - redis
-    command: python -m pytest
-    volumes:
-      - ./src:/code/src
+  # pytest:
+  #   build: 
+  #     context: .
+  #     dockerfile: Dockerfile 
+  #   env_file:
+  #     - ./src/.env 
+  #   depends_on:
+  #     - db
+  #     - create_superuser
+  #     - redis
+  #   command: python -m pytest
+  #   volumes:
+  #     - ./src:/code/src
 
 volumes:
   postgres-data:

--- a/src/app/api/v1/posts.py
+++ b/src/app/api/v1/posts.py
@@ -23,7 +23,7 @@ async def write_post(
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False)
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
@@ -44,11 +44,11 @@ async def read_posts(
     username: str, 
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False)
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
-    posts = await crud_posts.get_multi(db=db, created_by_user_id=db_user.id, is_deleted=False)
+    posts = await crud_posts.get_multi(db=db, schema_to_select=PostRead, created_by_user_id=db_user.id, is_deleted=False)
     return posts
 
 
@@ -60,11 +60,11 @@ async def read_post(
     id: int, 
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False)
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
-    db_post = await crud_posts.get(db=db, id=id, created_by_user_id=db_user.id, is_deleted=False)
+    db_post = await crud_posts.get(db=db, schema_to_select=PostRead, id=id, created_by_user_id=db_user.id, is_deleted=False)
     if db_post is None:
         raise HTTPException(status_code=404, detail="Post not found")
 
@@ -85,14 +85,14 @@ async def patch_post(
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False)
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
     if current_user.id != db_user.id:
         raise privileges_exception
 
-    db_post = await crud_posts.get(db=db, id=id, is_deleted=False)
+    db_post = await crud_posts.get(db=db, schema_to_select=PostRead, id=id, is_deleted=False)
     if db_post is None:
         raise HTTPException(status_code=404, detail="Post not found")
     
@@ -113,14 +113,14 @@ async def erase_post(
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False)
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
     if current_user.id != db_user.id:
         raise privileges_exception
 
-    db_post = await crud_posts.get(db=db, id=id, is_deleted=False)
+    db_post = await crud_posts.get(db=db, schema_to_select=PostRead, id=id, is_deleted=False)
     if db_post is None:
         raise HTTPException(status_code=404, detail="Post not found")
     
@@ -141,11 +141,11 @@ async def erase_db_post(
     id: int,
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_user = await crud_users.get(db=db, username=username, is_deleted=False)
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
-    db_post = await crud_posts.get(db=db, id=id, is_deleted=False)
+    db_post = await crud_posts.get(db=db, schema_to_select=PostRead, id=id, is_deleted=False)
     if db_post is None:
         raise HTTPException(status_code=404, detail="Post not found")
     

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -117,3 +117,8 @@ async def erase_db_user(
     
     db_user = await crud_users.db_delete(db=db, username=username)
     return {"message": "User deleted from the database"}
+
+@router.get("/deleted_users")
+async def read_users(request: Request, db: Annotated[AsyncSession, Depends(async_get_db)]):
+    users = await crud_users.get_multi(db=db, schema_to_select=UserRead, is_deleted=True)
+    return users

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -6,7 +6,7 @@ from sqlalchemy import select, update, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.engine.row import Row
 
-from .helper import _extract_matching_columns_from_schema, _extract_matching_columns_from_kwargs
+from .helper import _extract_matching_columns_from_schema, _extract_matching_columns_from_kwargs, _extract_matching_columns_from_column_names
 
 ModelType = TypeVar("ModelType")
 CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -2,8 +2,11 @@ from typing import Any, Dict, Generic, List, Type, TypeVar, Union
 from datetime import datetime
 
 from pydantic import BaseModel
-from sqlalchemy import select, update
+from sqlalchemy import select, update, delete
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.engine.row import Row
+
+from .helper import _extract_matching_columns_from_schema, _extract_matching_columns_from_kwargs
 
 ModelType = TypeVar("ModelType")
 CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
@@ -24,78 +27,68 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         await db.commit()
         return db_object
 
-    async def get(self, db: AsyncSession, **kwargs) -> ModelType | None:
-        query = select(self._model).filter_by(**kwargs)
-        result = await db.execute(query)
-        return result.scalar_one_or_none()
+    async def get(self, db: AsyncSession, schema_to_select: Type[BaseModel] | None = None, **kwargs) -> ModelType | None:
+        to_select = _extract_matching_columns_from_schema(model=self._model, schema=schema_to_select)
+        stmt = select(*to_select) \
+            .filter_by(**kwargs)
+        
+        result = await db.execute(stmt)
+        return result.first()
     
-    async def get_multi(
-            self, db: AsyncSession, offset: int = 0, limit: int = 100, **kwargs
-    ) -> List[ModelType]:
-        query = select(self._model) \
+    async def get_multi(self, db: AsyncSession, offset: int = 0, limit: int = 100, schema_to_select: Type[BaseModel] | None = None, **kwargs) -> List[ModelType]:
+        to_select = _extract_matching_columns_from_schema(model=self._model, schema=schema_to_select)
+        stmt = select(*to_select) \
             .filter_by(**kwargs) \
             .offset(offset) \
             .limit(limit)
         
-        result = await db.execute(query)
-        return result.scalars().all()
+        result = await db.execute(stmt)
+        return result.all()
+    
+    async def exists(self, db: AsyncSession, **kwargs) -> bool:
+        to_select = _extract_matching_columns_from_kwargs(model=self._model, kwargs=kwargs)
+        stmt = select(*to_select) \
+            .filter_by(**kwargs) \
+            .limit(1)
+        result = await db.execute(stmt)
+        
+        return result.first() is not None
+        
+    async def update(self, db: AsyncSession, object: Union[UpdateSchemaType, Dict[str, Any]], **kwargs) -> ModelType | None:
+        if isinstance(object, dict):
+            update_data = object
+        else:
+            update_data = object.model_dump(exclude_unset=True)
+        update_data["updated_at"] = datetime.utcnow()
 
-    async def update(
-            self,
-            db: AsyncSession,
-            object: Union[UpdateSchemaType, Dict[str, Any]],
-            db_object: ModelType | None = None,
-            **kwargs
-    ) -> ModelType | None:
-        db_object = db_object or await self.get(db=db, **kwargs)
-        if db_object:
-            if isinstance(object, dict):
-                update_data = object
-            else:
-                update_data = object.model_dump(exclude_unset=True)
-            
-            update_data.update({"updated_at": datetime.utcnow()})
-            for field in object.__dict__:
-                if field in update_data:
-                    setattr(db_object, field, update_data[field])
-            db.add(db_object)
-            await db.commit()
-
-        return db_object
-
-    async def db_delete(
-            self,
-            db: AsyncSession,
-            db_object: ModelType | None = None,
-            **kwargs
-    ):
-        db_object = db_object or await self.get(db=db, **kwargs)
-        await db.delete(db_object)
+        stmt = update(self._model) \
+            .filter_by(**kwargs) \
+            .values(update_data)
+        
+        await db.execute(stmt)
         await db.commit()
 
-        return db_object
+    async def db_delete(self, db: AsyncSession, **kwargs):
+        stmt = delete(self._model).filter_by(**kwargs)
+        await db.execute(stmt)
+        await db.commit()
 
-    async def delete(
-            self,
-            db: AsyncSession,
-            db_object: ModelType | None = None,
-            **kwargs
-    ) -> ModelType | None:
-        db_object = db_object or await self.get(db=db, **kwargs)
-        if db_object:
-            if "is_deleted" in db_object.__dict__.keys():
+    async def delete(self, db: AsyncSession, db_row: Row | None = None, **kwargs) -> ModelType | None:
+        db_row = db_row or await self.get(db=db, **kwargs)
+        if db_row:
+            if "is_deleted" in db_row:
                 object_dict = {
                     "is_deleted": True,
                     "deleted_at": datetime.utcnow()
                 }
-                query = update(self._model) \
+                stmt = update(self._model) \
                     .filter_by(**kwargs) \
                     .values(object_dict)
                 
-                await db.execute(query)
+                await db.execute(stmt)
                 await db.commit()
-                await db.refresh(db_object)
-            else:
-                db_object = await self.db_delete(db=db, db_object=db_object, **kwargs)
 
-        return db_object
+            else:
+                stmt = delete(self._model).filter_by(**kwargs)
+                await db.execute(stmt)
+                await db.commit()

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -228,9 +228,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         -------
         None
         """
-        db_row = db_row or await self.get(db=db, **kwargs)
+        db_row = db_row or await self.exists(db=db, **kwargs)
         if db_row:
-            if "is_deleted" in db_row:
+            if "is_deleted" in self._model.__table__.columns:
                 object_dict = {
                     "is_deleted": True,
                     "deleted_at": datetime.utcnow()

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -6,7 +6,7 @@ from sqlalchemy import select, update, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.engine.row import Row
 
-from .helper import _extract_matching_columns_from_schema, _extract_matching_columns_from_kwargs, _extract_matching_columns_from_column_names
+from .helper import _extract_matching_columns_from_schema, _extract_matching_columns_from_kwargs
 
 ModelType = TypeVar("ModelType")
 CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
@@ -15,19 +15,66 @@ UpdateSchemaInternalType = TypeVar("UpdateSchemaInternalType", bound=BaseModel)
 DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 
 class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSchemaInternalType, DeleteSchemaType]):
+    """
+    Base class for CRUD operations on a model.
+
+    Parameters
+    ----------
+    model : Type[ModelType]
+        The SQLAlchemy model type.
+    """
     def __init__(self, model: Type[ModelType]) -> None:
         self._model = model
 
     async def create(
-            self, db: AsyncSession, object: CreateSchemaType
+            self, 
+            db: AsyncSession, 
+            object: CreateSchemaType
     ) -> ModelType:
+        """
+        Create a new record in the database.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        object : CreateSchemaType
+            The Pydantic schema containing the data to be saved.
+
+        Returns
+        -------
+        ModelType
+            The created database object.
+        """
         object_dict = object.model_dump()
         db_object = self._model(**object_dict)
         db.add(db_object)
         await db.commit()
         return db_object
 
-    async def get(self, db: AsyncSession, schema_to_select: Type[BaseModel] | None = None, **kwargs) -> ModelType | None:
+    async def get(
+            self, 
+            db: AsyncSession, 
+            schema_to_select: Type[BaseModel] | None = None, 
+            **kwargs
+    ) -> ModelType | None:
+        """
+        Fetch a single record based on filters.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        schema_to_select : Type[BaseModel] | None, optional
+            Pydantic schema for selecting specific columns. Default is None to select all columns.
+        kwargs : dict
+            Filters to apply to the query.
+
+        Returns
+        -------
+        ModelType | None
+            The fetched database row or None if not found.
+        """
         to_select = _extract_matching_columns_from_schema(model=self._model, schema=schema_to_select)
         stmt = select(*to_select) \
             .filter_by(**kwargs)
@@ -35,7 +82,35 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         result = await db.execute(stmt)
         return result.first()
     
-    async def get_multi(self, db: AsyncSession, offset: int = 0, limit: int = 100, schema_to_select: Type[BaseModel] | None = None, **kwargs) -> List[ModelType]:
+    async def get_multi(
+            self, 
+            db: AsyncSession, 
+            offset: int = 0, 
+            limit: int = 100, 
+            schema_to_select: Type[BaseModel] | None = None, 
+            **kwargs
+    ) -> List[ModelType]:
+        """
+        Fetch multiple records based on filters.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        offset : int, optional
+            Number of rows to skip before fetching. Default is 0.
+        limit : int, optional
+            Maximum number of rows to fetch. Default is 100.
+        schema_to_select : Type[BaseModel] | None, optional
+            Pydantic schema for selecting specific columns. Default is None to select all columns.
+        kwargs : dict
+            Filters to apply to the query.
+
+        Returns
+        -------
+        List[ModelType]
+            List of fetched database rows.
+        """
         to_select = _extract_matching_columns_from_schema(model=self._model, schema=schema_to_select)
         stmt = select(*to_select) \
             .filter_by(**kwargs) \
@@ -45,7 +120,26 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         result = await db.execute(stmt)
         return result.all()
     
-    async def exists(self, db: AsyncSession, **kwargs) -> bool:
+    async def exists(
+            self, 
+            db: AsyncSession, 
+            **kwargs
+    ) -> bool:
+        """
+        Check if a record exists based on filters.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        kwargs : dict
+            Filters to apply to the query.
+
+        Returns
+        -------
+        bool
+            True if a record exists, False otherwise.
+        """
         to_select = _extract_matching_columns_from_kwargs(model=self._model, kwargs=kwargs)
         stmt = select(*to_select) \
             .filter_by(**kwargs) \
@@ -54,7 +148,28 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         
         return result.first() is not None
         
-    async def update(self, db: AsyncSession, object: Union[UpdateSchemaType, Dict[str, Any]], **kwargs) -> ModelType | None:
+    async def update(
+            self, 
+            db: AsyncSession, 
+            object: Union[UpdateSchemaType, Dict[str, Any]], 
+            **kwargs
+    ) -> None:
+        """
+        Update an existing record in the database.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        object : Union[UpdateSchemaType, Dict[str, Any]]
+            The Pydantic schema or dictionary containing the data to be updated.
+        kwargs : dict
+            Filters for the update.
+
+        Returns
+        -------
+        None
+        """
         if isinstance(object, dict):
             update_data = object
         else:
@@ -68,12 +183,51 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         await db.execute(stmt)
         await db.commit()
 
-    async def db_delete(self, db: AsyncSession, **kwargs):
+    async def db_delete(
+            self, 
+            db: AsyncSession, 
+            **kwargs
+    ) -> None:
+        """
+        Delete a record in the database.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        kwargs : dict
+            Filters for the delete.
+
+        Returns
+        -------
+        None
+        """
         stmt = delete(self._model).filter_by(**kwargs)
         await db.execute(stmt)
         await db.commit()
 
-    async def delete(self, db: AsyncSession, db_row: Row | None = None, **kwargs) -> ModelType | None:
+    async def delete(
+            self, 
+            db: AsyncSession, 
+            db_row: Row | None = None, 
+            **kwargs
+    ) -> None:
+        """
+        Soft delete a record if it has "is_deleted" attribute, otherwise perform a hard delete.
+
+        Parameters
+        ----------
+        db : AsyncSession
+            The SQLAlchemy async session.
+        db_row : Row | None, optional
+            Existing database row to delete. If None, it will be fetched based on `kwargs`. Default is None.
+        kwargs : dict
+            Filters for fetching the database row if not provided.
+
+        Returns
+        -------
+        None
+        """
         db_row = db_row or await self.get(db=db, **kwargs)
         if db_row:
             if "is_deleted" in db_row:

--- a/src/app/crud/helper.py
+++ b/src/app/crud/helper.py
@@ -22,7 +22,7 @@ def _extract_matching_columns_from_schema(model: Type[Base], schema: Type[BaseMo
     """
     column_list = list(model.__table__.columns)
     if schema is not None:
-        schema_fields = schema.__fields__.keys()
+        schema_fields = schema.model_fields.keys()
         column_list = []
         for column_name in schema_fields:
             if hasattr(model, column_name):

--- a/src/app/crud/helper.py
+++ b/src/app/crud/helper.py
@@ -1,0 +1,42 @@
+from typing import Any, List, Type
+
+from pydantic import BaseModel
+
+from app.core.database import Base
+
+def _extract_matching_columns_from_schema(model: Type[Base], schema: Type[BaseModel] | None) -> List[Any]:
+    """
+    Retrieves a list of ORM column objects from a SQLAlchemy model that match the field names in a given Pydantic schema.
+
+    Parameters
+    ----------
+    model: Type[Base]
+        The SQLAlchemy ORM model containing columns to be matched with the schema fields.
+    schema: Type[BaseModel]
+        The Pydantic schema containing field names to be matched with the model's columns.
+
+    Returns
+    -------
+    List[Any]
+        A list of ORM column objects from the model that correspond to the field names defined in the schema.
+    """
+    column_list = list(model.__table__.columns)
+    if schema is not None:
+        schema_fields = schema.__fields__.keys()
+        column_list = []
+        for column_name in schema_fields:
+            if hasattr(model, column_name):
+                column_list.append(getattr(model, column_name))
+    
+    return column_list
+
+
+def _extract_matching_columns_from_kwargs(model: Type[Base], kwargs: dict) -> List[Any]:
+    if kwargs is not None:
+        kwargs_fields = kwargs.keys()
+        column_list = []
+        for column_name in kwargs_fields:
+            if hasattr(model, column_name):
+                column_list.append(getattr(model, column_name))
+    
+    return column_list

--- a/src/app/crud/helper.py
+++ b/src/app/crud/helper.py
@@ -40,3 +40,12 @@ def _extract_matching_columns_from_kwargs(model: Type[Base], kwargs: dict) -> Li
                 column_list.append(getattr(model, column_name))
     
     return column_list
+
+
+def _extract_matching_columns_from_column_names(model: Type[Base], column_names: List) -> List[Any]:
+    column_list = []
+    for column_name in column_names:
+        if hasattr(model, column_name):
+            column_list.append(getattr(model, column_name))
+
+    return column_list

--- a/src/app/schemas/user.py
+++ b/src/app/schemas/user.py
@@ -39,6 +39,10 @@ class UserRead(BaseModel):
         str, 
         Field(min_length=2, max_length=20, pattern=r"^[a-z0-9]+$", examples=["userson"])
     ]
+    email: Annotated[
+        EmailStr, 
+        Field(examples=["user.userson@example.com"])
+    ]
     profile_image_url: str
 
 


### PR DESCRIPTION
Now it's possible to select only a few attributes in a query.

For the `get` and `get_multi` methods we have the option to define a `schema_to_select` attribute, which is what actually makes the queries more efficient. When you pass a pydantic schema in `schema_to_select` to the `get` or `get_multi` methods, only the attributes in the schema will be selected.
```python
from app.schemas.user import UserRead
# Here it's selecting all of the user's data
crud_user.get(db=db, username="myusername")

# Now it's only selecting the data that is in UserRead. 
# Since that's my response_model, it's all I need
crud_user.get(db=db, username="myusername", schema_to_select=UserRead)
```