### PR TITLE
Rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - 🚦 ARQ integration for task queue
 - ⚙️ Efficient querying (only queries what's needed)
 - ⎘ Out of the box pagination support
+- 🛑 Rate Limiter dependency
 - 👮 FastAPI docs behind authentication and hidden based on the environment
 - 🦾 Easily extendable
 - 🤸‍♂️ Flexible
@@ -64,7 +65,7 @@
 - [ ] Docs for other databases (MysQL, SQLite)
 
 #### Features
-- [ ] Add a Rate Limiter dependency
+- [x] Add a Rate Limiter dependency
 - [ ] Add mongoDB support
 
 #### Tests
@@ -100,7 +101,8 @@
     8. [Caching](#58-caching)
     9. [More Advanced Caching](#59-more-advanced-caching)
     10. [ARQ Job Queues](#510-arq-job-queues)
-    11. [Running](#511-running)
+    11. [Rate Limiting](#511-rate-limiting)
+    12. [Running](#512-running)
 7. [Running in Production](#6-running-in-production)
 8. [Testing](#7-testing)
 9. [Contributing](#8-contributing)
@@ -194,6 +196,24 @@ REDIS_CACHE_PORT=6379
 ```
 > **Warning** 
 > You may use the same redis for both caching and queue while developing, but the recommendation is using two separate containers for production.
+
+To create the first tier:
+```
+# ------------- first tier -------------
+TIER_NAME="free"
+```
+
+For the rate limiter:
+```
+# ------------- redis rate limit -------------
+REDIS_RATE_LIMIT_HOST="localhost"   # default="localhost"
+REDIS_RATE_LIMIT_PORT=6379          # default=6379
+
+
+# ------------- default rate limit settings -------------
+DEFAULT_RATE_LIMIT_LIMIT=10         # default=10
+DEFAULT_RATE_LIMIT_PERIOD=3600      # default=3600
+```
 
 For tests (optional to run):
 ```
@@ -368,12 +388,14 @@ to stop the create_superuser service:
 docker-compose stop create_superuser
 ```
 
-
 #### 4.3.2 From Scratch
 While in the `src` folder, run (after you started the application at least once to create the tables):
 ```sh
 poetry run python -m scripts.create_first_superuser
 ```
+
+### 4.3.3 Creating the first tier
+To create the first tier it's similar, you just replace `create_superuser` for `create_tier`. If using `docker compose`, do not forget to uncomment the `create_tier` service in `docker-compose.yml`.
 
 ### 4.4 Database Migrations
 While in the `src` folder, run Alembic migrations:
@@ -473,7 +495,7 @@ First, you may want to take a look at the project structure and understand what 
 
 ### 5.2 Database Model
 Create the new entities and relationships and add them to the model
-![diagram](https://user-images.githubusercontent.com/43156212/274053323-31bbdb41-15bf-45f2-8c8e-0b04b71c5b0b.png)
+![diagram](https://user-images.githubusercontent.com/43156212/282272311-c7a36e26-dcd0-42cf-939d-6434b5579f29.png)
 
 ### 5.3 SQLAlchemy Models
 Inside `app/models`, create a new `entity.py` for each new entity (replacing entity with the name) and define the attributes according to [SQLAlchemy 2.0 standards](https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html#orm-mapping-styles):
@@ -832,6 +854,8 @@ Passing resource_id_name is usually preferred.
 The behaviour of the `cache` decorator changes based on the request method of your endpoint. 
 It caches the result if you are passing it to a **GET** endpoint, and it invalidates the cache with this key_prefix and id if passed to other endpoints (**PATCH**, **DELETE**).
 
+
+#### Invalidating Extra Keys
 If you also want to invalidate cache with a different key, you can use the decorator with the `to_invalidate_extra` variable.
 
 In the following example, I want to invalidate the cache for a certain `user_id`, since I'm deleting it, but I also want to invalidate the cache for the list of users, so it will not be out of sync.
@@ -886,6 +910,68 @@ async def patch_post(
 > **Warning**
 > Note that adding `to_invalidate_extra` will not work for **GET** requests.
 
+#### Invalidate Extra By Pattern
+Let's assume we have an endpoint with a paginated response, such as:
+```python
+@router.get("/{username}/posts", response_model=PaginatedListResponse[PostRead])
+@cache(
+    key_prefix="{username}_posts:page_{page}:items_per_page:{items_per_page}", 
+    resource_id_name="username",
+    expiration=60
+)
+async def read_posts(
+    request: Request,
+    username: str,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    page: int = 1,
+    items_per_page: int = 10
+):
+    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    posts_data = await crud_posts.get_multi(
+        db=db,
+        offset=compute_offset(page, items_per_page),
+        limit=items_per_page,
+        schema_to_select=PostRead,
+        created_by_user_id=db_user["id"],
+        is_deleted=False
+    )
+
+    return paginated_response(
+        crud_data=posts_data, 
+        page=page, 
+        items_per_page=items_per_page
+    )
+```
+
+Just passing `to_invalidate_extra` will not work to invalidate this cache, since the key will change based on the `page` and `items_per_page` values.
+To overcome this we may use the `pattern_to_invalidate_extra` parameter:
+
+```python
+@router.patch("/{username}/post/{id}")
+@cache(
+    "{username}_post_cache", 
+    resource_id_name="id", 
+    pattern_to_invalidate_extra=["{username}_posts:*"]
+)
+async def patch_post(
+    request: Request,
+    username: str,
+    id: int,
+    values: PostUpdate,
+    current_user: Annotated[UserRead, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+...
+```
+
+Now it will invalidate all caches with a key that matches the pattern `"{username}_posts:*`, which will work for the paginated responses.
+
+> **Warning**
+> Using `pattern_to_invalidate_extra` can be resource-intensive on large datasets. Use it judiciously and consider the potential impact on Redis performance. Be cautious with patterns that could match a large number of keys, as deleting many keys simultaneously may impact the performance of the Redis server.
+
 #### Client-side Caching
 For `client-side caching`, all you have to do is let the `Settings` class defined in `app/core/config.py` inherit from the `ClientSideCacheSettings` class. You can set the `CLIENT_CACHE_MAX_AGE` value in `.env,` it defaults to 60 (seconds).
 
@@ -931,8 +1017,115 @@ If you are doing it from scratch, run while in the `src` folder:
 ```sh
 poetry run arq app.worker.WorkerSettings
 ```
+### 5.11 Rate Limiting
+To limit how many times a user can make a request in a certain interval of time (very useful to create subscription plans or just to protect your API against DDOS), you may just use the `rate_limiter` dependency:
 
-### 5.11 Running
+```python
+from fastapi import Depends
+
+from app.api.dependencies import rate_limiter
+from app.core import queue
+from app.schemas.job import Job
+
+@router.post("/task", response_model=Job, status_code=201, dependencies=[Depends(rate_limiter)])
+async def create_task(message: str):
+    job = await queue.pool.enqueue_job("sample_background_task", message)
+    return {"id": job.job_id}
+```
+
+By default, if no token is passed in the header (that is - the user is not authenticated), the user will be limited by his IP address with the default `limit` (how many times the user can make this request every period) and `period` (time in seconds) defined in `.env`.
+
+Even though this is useful, real power comes from creating `tiers` (categories of users) and standard `rate_limits` (`limits` and `periods` defined for specific `paths` - that is - endpoints) for these tiers. 
+
+All of the `tier` and `rate_limit` models, schemas, and endpoints are already created in the respective folders (and usable only by superusers). You may use the `create_tier` script to create the first tier (it uses the `.env` variable `TIER_NAME`, which is all you need to create a tier) or just use the api:
+
+Here I'll create a `free` tier:
+
+<p align="left">
+    <img src="https://user-images.githubusercontent.com/43156212/282275103-d9c4f511-4cfa-40c6-b882-5b09df9f62b9.png" width="70%" height="auto">
+</p>
+
+And a `pro` tier:
+
+<p align="left">
+    <img src="https://user-images.githubusercontent.com/43156212/282275107-5a6ca593-ccc0-4965-b2db-09ec5ecad91c.png" width="70%" height="auto">
+</p>
+
+Then I'll associate a `rate_limit` for the path `api/v1/tasks/task` for each of them, I'll associate a `rate limit` for the path `api/v1/tasks/task`. 
+
+1 request every hour (3600 seconds) for the free tier: 
+
+<p align="left">
+    <img src="https://user-images.githubusercontent.com/43156212/282275105-95d31e19-b798-4f03-98f0-3e9d1844f7b3.png" width="70%" height="auto">
+</p>
+
+10 requests every hour for the pro tier:
+
+<p align="left">
+    <img src="https://user-images.githubusercontent.com/43156212/282275108-deec6f46-9d47-4f01-9899-ca42da0f0363.png" width="70%" height="auto">
+</p>
+
+Now let's read all the tiers available (`GET api/v1/tiers`): 
+
+```javascript
+{
+  "data": [
+    {
+      "name": "free",
+      "id": 1,
+      "created_at": "2023-11-11T05:57:25.420360"
+    },
+    {
+      "name": "pro",
+      "id": 2,
+      "created_at": "2023-11-12T00:40:00.759847"
+    }
+  ],
+  "total_count": 2,
+  "has_more": false,
+  "page": 1,
+  "items_per_page": 10
+}
+```
+
+And read the `rate_limits` for the `pro` tier to ensure it's working (`GET api/v1/tier/pro/rate_limits`):
+
+```javascript
+{
+  "data": [
+    {
+      "path": "api_v1_tasks_task",
+      "limit": 10,
+      "period": 3600,
+      "id": 1,
+      "tier_id": 2,
+      "name": "api_v1_tasks:10:3600"
+    }
+  ],
+  "total_count": 1,
+  "has_more": false,
+  "page": 1,
+  "items_per_page": 10
+}
+```
+
+Now, whenever an authenticated user makes a `POST` request to the `api/v1/tasks/task`, they'll use the quota that is defined by their tier. 
+You may check this getting the token from the `api/v1/login` endpoint, then passing it in the request header:
+```sh
+curl -X POST 'http://127.0.0.1:8000/api/v1/tasks/task?message=test' \
+-H 'Authorization: Bearer <your-token-here>'
+```
+
+> **Warning**
+> Since the `rate_limiter` dependency uses the `get_optional_user` dependency instead of `get_current_user`, it will not require authentication to be used, but will behave accordingly if the user is authenticated (and token is passed in header). If you want to ensure authentication, also use `get_current_user` if you need.
+
+To change a user's tier, you may just use the `PATCH api/v1/user/{username}/tier` endpoint.
+Note that for flexibility (since this is a boilerplate), it's not necessary to previously inform a tier_id to create a user, but you probably should set every user to a certain tier (let's say `free`) once they are created. 
+
+> **Warning**
+> If a user does not have a `tier` or the tier does not have a defined `rate limit` for the path and the token is still passed to the request, the default `limit` and `period` will be used, this will be saved in `app/logs`.
+
+### 5.12 Running
 If you are using docker compose, just running the following command should ensure everything is working:
 ```sh
 docker compose up

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 - [ ] Docs for other databases (MysQL, SQLite)
 
 #### Features
-- [ ] Add a Rate Limiter decorator
+- [ ] Add a Rate Limiter dependency
 - [ ] Add mongoDB support
 
 #### Tests

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://github.com/igormagalhaesr/FastAPI-boilerplate">
-    <img src="https://user-images.githubusercontent.com/43156212/277095260-ef5d4496-8290-4b18-99b2-0c0b5500504e.png" width="35%" height="auto">
+    <img src="https://user-images.githubusercontent.com/43156212/277095260-ef5d4496-8290-4b18-99b2-0c0b5500504e.png" alt="Blue Rocket with FastAPI Logo as its window. There is a word FAST written" width="35%" height="auto">
   </a>
 </p>
 
@@ -114,7 +114,7 @@ ___
 ## 3. Prerequisites
 Start by using the template, and naming the repository to what you want.
 <p align="left">
-    <img src="https://user-images.githubusercontent.com/43156212/277866726-975d1c98-b1c9-4c8e-b4bd-001c8a5728cb.png" width="35%" height="auto">
+    <img src="https://user-images.githubusercontent.com/43156212/277866726-975d1c98-b1c9-4c8e-b4bd-001c8a5728cb.png" alt="clicking use this template button, then create a new repository option" width="35%" height="auto">
 </p>
 
 Then clone your created repository (I'm using the base for the example)
@@ -1042,13 +1042,13 @@ All of the `tier` and `rate_limit` models, schemas, and endpoints are already cr
 Here I'll create a `free` tier:
 
 <p align="left">
-    <img src="https://user-images.githubusercontent.com/43156212/282275103-d9c4f511-4cfa-40c6-b882-5b09df9f62b9.png" width="70%" height="auto">
+    <img src="https://user-images.githubusercontent.com/43156212/282275103-d9c4f511-4cfa-40c6-b882-5b09df9f62b9.png" alt="passing name = free to api request body" width="70%" height="auto">
 </p>
 
 And a `pro` tier:
 
 <p align="left">
-    <img src="https://user-images.githubusercontent.com/43156212/282275107-5a6ca593-ccc0-4965-b2db-09ec5ecad91c.png" width="70%" height="auto">
+    <img src="https://user-images.githubusercontent.com/43156212/282275107-5a6ca593-ccc0-4965-b2db-09ec5ecad91c.png" alt="passing name = pro to api request body" width="70%" height="auto">
 </p>
 
 Then I'll associate a `rate_limit` for the path `api/v1/tasks/task` for each of them, I'll associate a `rate limit` for the path `api/v1/tasks/task`. 
@@ -1056,13 +1056,13 @@ Then I'll associate a `rate_limit` for the path `api/v1/tasks/task` for each of 
 1 request every hour (3600 seconds) for the free tier: 
 
 <p align="left">
-    <img src="https://user-images.githubusercontent.com/43156212/282275105-95d31e19-b798-4f03-98f0-3e9d1844f7b3.png" width="70%" height="auto">
+    <img src="https://user-images.githubusercontent.com/43156212/282275105-95d31e19-b798-4f03-98f0-3e9d1844f7b3.png" alt="passing path=api/v1/tasks/task, limit=1, period=3600, name=api_v1_tasks:1:3600 to free tier rate limit" width="70%" height="auto">
 </p>
 
 10 requests every hour for the pro tier:
 
 <p align="left">
-    <img src="https://user-images.githubusercontent.com/43156212/282275108-deec6f46-9d47-4f01-9899-ca42da0f0363.png" width="70%" height="auto">
+    <img src="https://user-images.githubusercontent.com/43156212/282275108-deec6f46-9d47-4f01-9899-ca42da0f0363.png" alt="passing path=api/v1/tasks/task, limit=10, period=3600, name=api_v1_tasks:10:3600 to pro tier rate limit" width="70%" height="auto">
 </p>
 
 Now let's read all the tiers available (`GET api/v1/tiers`): 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,17 +46,18 @@ services:
       - redis-data:/data
 
   # #-------- uncomment to create first superuser --------
-  # create_superuser:
-  #   build: 
-  #     context: .
-  #     dockerfile: Dockerfile
-  #   env_file:
-  #     - ./src/.env
-  #   depends_on:
-  #     - db
-  #   command: python -m src.scripts.create_first_superuser
-  #   volumes:
-  #     - ./src:/code/src
+  create_superuser:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - ./src/.env
+    depends_on:
+      - db
+      - web
+    command: python -m src.scripts.create_first_superuser
+    volumes:
+      - ./src:/code/src
 
   # #-------- uncomment to run tests --------
   # pytest:
@@ -73,6 +74,21 @@ services:
   #   volumes:
   #     - ./src:/code/src
 
+# #-------- uncomment to create first tier --------
+  create_tier:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - ./src/.env
+    depends_on:
+      - db
+      - web
+    command: python -m src.scripts.create_first_tier
+    volumes:
+      - ./src:/code/src
+
 volumes:
   postgres-data:
   redis-data:
+ 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,48 +45,48 @@ services:
     volumes:
       - redis-data:/data
 
-  # #-------- uncomment to create first superuser --------
-  create_superuser:
-    build: 
-      context: .
-      dockerfile: Dockerfile
-    env_file:
-      - ./src/.env
-    depends_on:
-      - db
-      - web
-    command: python -m src.scripts.create_first_superuser
-    volumes:
-      - ./src:/code/src
+#   #-------- uncomment to create first superuser --------
+#   create_superuser:
+#     build: 
+#       context: .
+#       dockerfile: Dockerfile
+#     env_file:
+#       - ./src/.env
+#     depends_on:
+#       - db
+#       - web
+#     command: python -m src.scripts.create_first_superuser
+#     volumes:
+#       - ./src:/code/src
 
-  # #-------- uncomment to run tests --------
-  # pytest:
-  #   build: 
-  #     context: .
-  #     dockerfile: Dockerfile 
-  #   env_file:
-  #     - ./src/.env 
-  #   depends_on:
-  #     - db
-  #     - create_superuser
-  #     - redis
-  #   command: python -m pytest
-  #   volumes:
-  #     - ./src:/code/src
+#   #-------- uncomment to run tests --------
+#   # pytest:
+#   #   build: 
+#   #     context: .
+#   #     dockerfile: Dockerfile 
+#   #   env_file:
+#   #     - ./src/.env 
+#   #   depends_on:
+#   #     - db
+#   #     - create_superuser
+#   #     - redis
+#   #   command: python -m pytest
+#   #   volumes:
+#   #     - ./src:/code/src
 
-# #-------- uncomment to create first tier --------
-  create_tier:
-    build: 
-      context: .
-      dockerfile: Dockerfile
-    env_file:
-      - ./src/.env
-    depends_on:
-      - db
-      - web
-    command: python -m src.scripts.create_first_tier
-    volumes:
-      - ./src:/code/src
+#   #-------- uncomment to create first tier --------
+#   create_tier:
+#     build: 
+#       context: .
+#       dockerfile: Dockerfile
+#     env_file:
+#       - ./src/.env
+#     depends_on:
+#       - db
+#       - web
+#     command: python -m src.scripts.create_first_tier
+#     volumes:
+#       - ./src:/code/src
 
 volumes:
   postgres-data:

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -8,15 +8,17 @@ from jose import JWTError, jwt
 from fastapi import (
     Depends, 
     HTTPException, 
-    Request, 
+    Request,
     status
 )
 
 from app.core.database import async_get_db
 from app.core.models import TokenData
+# from app.core.rate_limit import is_rate_limited
 from app.models.user import User
-from app.crud.crud_users import crud_users
 from app.api.exceptions import credentials_exception, privileges_exception
+from app.crud.crud_users import crud_users
+from app.crud.crud_tier import crud_tiers
 
 async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: Annotated[AsyncSession, Depends(async_get_db)]) -> User:
     try:

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -1,32 +1,44 @@
 from typing import Annotated
 
 from app.core.security import SECRET_KEY, ALGORITHM, oauth2_scheme
-from app.core.config import RedisRateLimiterSettings, settings
+from app.core.config import settings
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from jose import JWTError, jwt
 from fastapi import (
     Depends, 
     HTTPException, 
-    Request,
-    status
+    Request
 )
 
 from app.core.database import async_get_db
 from app.core.models import TokenData
-# from app.core.rate_limit import is_rate_limited
+from app.core.rate_limit import is_rate_limited
+from app.core.logger import logging
 from app.models.user import User
 from app.api.exceptions import credentials_exception, privileges_exception
 from app.crud.crud_users import crud_users
 from app.crud.crud_tier import crud_tiers
+from app.crud.crud_rate_limit import crud_rate_limits
+from app.schemas.rate_limit import sanitize_path
 
-async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: Annotated[AsyncSession, Depends(async_get_db)]) -> User:
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LIMIT = settings.DEFAULT_RATE_LIMIT_LIMIT
+DEFAULT_PERIOD = settings.DEFAULT_RATE_LIMIT_PERIOD
+
+async def get_current_user(
+    token: Annotated[str, Depends(oauth2_scheme)],
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+) -> User | None:
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         username_or_email: str = payload.get("sub")
         if username_or_email is None:
             raise credentials_exception
         token_data = TokenData(username_or_email=username_or_email)
+    
     except JWTError:
         raise credentials_exception
     
@@ -35,16 +47,80 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: An
     else: 
         user = await crud_users.get(db=db, username=token_data.username_or_email)
     
-    if user is None:
-        raise credentials_exception
+    if user and not user["is_deleted"]:
+        return user
     
-    if user.is_deleted:
-        raise HTTPException(status_code=400, detail="User deleted")
+    raise credentials_exception
 
-    return user
+
+async def get_optional_user(
+    request: Request,
+    db: AsyncSession = Depends(async_get_db)
+) -> User | None:
+    token = request.headers.get("Authorization")
+    if not token:
+        return None
+
+    try:
+        token_type, _, token_value = token.partition(' ')
+        if token_type.lower() != 'bearer' or not token_value:
+            return None
+
+        return await get_current_user(token_value, db)
+    
+    except HTTPException as http_exc:
+        if http_exc.status_code != 401:
+            logger.error(f"Unexpected HTTPException in get_optional_user: {http_exc.detail}")
+        return None
+    
+    except Exception as exc:
+        logger.error(f"Unexpected error in get_optional_user: {exc}")
+        return None    
+
 
 async def get_current_superuser(current_user: Annotated[User, Depends(get_current_user)]) -> User:
-    if not current_user.is_superuser:
+    if not current_user["is_superuser"]:
         raise privileges_exception
     
     return current_user
+
+
+async def rate_limiter(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    user: User | None = Depends(get_optional_user)
+):
+    path = sanitize_path(request.url.path)
+    if user:
+        user_id = user["id"]
+        tier = await crud_tiers.get(db, id=user["tier_id"])
+        if tier:
+            rate_limit = await crud_rate_limits.get(
+                db=db,
+                tier_id=tier["id"],
+                path=path
+            )
+            if rate_limit:
+                limit, period = rate_limit["limit"], rate_limit["period"]
+            else:
+                logger.warning(f"User {user_id} with tier '{tier['name']}' has no specific rate limit for path '{path}'. Applying default rate limit.")
+                limit, period = DEFAULT_LIMIT, DEFAULT_PERIOD
+        else:
+            logger.warning(f"User {user_id} has no assigned tier. Applying default rate limit.")
+            limit, period = DEFAULT_LIMIT, DEFAULT_PERIOD
+    else:
+        user_id = request.client.host
+        limit, period = DEFAULT_LIMIT, DEFAULT_PERIOD
+
+    is_limited = await is_rate_limited(
+        db=db,
+        user_id=user_id,
+        path=path,
+        limit=limit,
+        period=period
+    )
+    if is_limited:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded"
+        )

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -1,10 +1,16 @@
 from typing import Annotated
 
 from app.core.security import SECRET_KEY, ALGORITHM, oauth2_scheme
+from app.core.config import RedisRateLimiterSettings, settings
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from jose import JWTError, jwt
-from fastapi import Depends, HTTPException
+from fastapi import (
+    Depends, 
+    HTTPException, 
+    Request, 
+    status
+)
 
 from app.core.database import async_get_db
 from app.core.models import TokenData

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -35,7 +35,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: An
 
     return user
 
-def get_current_superuser(current_user: Annotated[User, Depends(get_current_user)]) -> User:
+async def get_current_superuser(current_user: Annotated[User, Depends(get_current_user)]) -> User:
     if not current_user.is_superuser:
         raise privileges_exception
     

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -31,7 +31,7 @@ DEFAULT_PERIOD = settings.DEFAULT_RATE_LIMIT_PERIOD
 async def get_current_user(
     token: Annotated[str, Depends(oauth2_scheme)],
     db: Annotated[AsyncSession, Depends(async_get_db)]
-) -> User | None:
+) -> User:
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         username_or_email: str = payload.get("sub")

--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -4,9 +4,13 @@ from app.api.v1.login import router as login_router
 from app.api.v1.users import router as users_router
 from app.api.v1.posts import router as posts_router
 from app.api.v1.tasks import router as tasks_router
+from app.api.v1.tiers import router as tiers_router
+from app.api.v1.rate_limits import router as rate_limits_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(login_router)
 router.include_router(users_router)
 router.include_router(posts_router)
 router.include_router(tasks_router)
+router.include_router(tiers_router)
+router.include_router(rate_limits_router)

--- a/src/app/api/v1/login.py
+++ b/src/app/api/v1/login.py
@@ -29,7 +29,7 @@ async def login_for_access_token(
     
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = await create_access_token(
-        data={"sub": user.username}, expires_delta=access_token_expires
+        data={"sub": user["username"]}, expires_delta=access_token_expires
     )
     
     return {"access_token": access_token, "token_type": "bearer"}

--- a/src/app/api/v1/posts.py
+++ b/src/app/api/v1/posts.py
@@ -1,4 +1,4 @@
-from typing import List, Annotated
+from typing import Annotated
 
 from fastapi import Request, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,7 +28,7 @@ async def write_post(
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
-    if current_user.id != db_user["id"]:
+    if current_user["id"] != db_user["id"]:
         raise privileges_exception
 
     post_internal_dict = post.model_dump()
@@ -94,7 +94,7 @@ async def read_post(
 @cache(
     "{username}_post_cache", 
     resource_id_name="id", 
-    to_invalidate_extra={"{username}_posts": "{username}"}
+    pattern_to_invalidate_extra=["{username}_posts:*"]
 )
 async def patch_post(
     request: Request,
@@ -108,7 +108,7 @@ async def patch_post(
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
-    if current_user.id != db_user["id"]:
+    if current_user["id"] != db_user["id"]:
         raise privileges_exception
 
     db_post = await crud_posts.get(db=db, schema_to_select=PostRead, id=id, is_deleted=False)
@@ -136,7 +136,7 @@ async def erase_post(
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
     
-    if current_user.id != db_user.id:
+    if current_user["id"] != db_user["id"]:
         raise privileges_exception
 
     db_post = await crud_posts.get(db=db, schema_to_select=PostRead, id=id, is_deleted=False)

--- a/src/app/api/v1/posts.py
+++ b/src/app/api/v1/posts.py
@@ -39,7 +39,11 @@ async def write_post(
 
 
 @router.get("/{username}/posts", response_model=PaginatedListResponse[PostRead])
-@cache(key_prefix="{username}_posts", resource_id_name="username")
+@cache(
+    key_prefix="{username}_posts:page_{page}:items_per_page:{items_per_page}", 
+    resource_id_name="username",
+    expiration=60
+)
 async def read_posts(
     request: Request,
     username: str,
@@ -164,5 +168,5 @@ async def erase_db_post(
     if db_post is None:
         raise HTTPException(status_code=404, detail="Post not found")
     
-    await crud_posts.db_delete(db=db, db_object=db_post, id=id)
+    await crud_posts.db_delete(db=db, id=id)
     return {"message": "Post deleted from the database"}

--- a/src/app/api/v1/rate_limits.py
+++ b/src/app/api/v1/rate_limits.py
@@ -4,28 +4,28 @@ from fastapi import Request, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 import fastapi
 
+from app.api.dependencies import get_current_superuser
+from app.api.paginated import PaginatedListResponse, paginated_response, compute_offset
+from app.core.database import async_get_db
+from app.crud.crud_rate_limit import crud_rate_limits
+from app.crud.crud_tier import crud_tiers
 from app.schemas.rate_limit import (
     RateLimitRead,
     RateLimitCreate,
     RateLimitCreateInternal,
     RateLimitUpdate
 )
-from app.api.dependencies import get_current_superuser
-from app.core.database import async_get_db
-from app.crud.crud_rate_limit import crud_rate_limits
-from app.crud.crud_tier import crud_tiers
-from app.api.paginated import PaginatedListResponse, paginated_response, compute_offset
 
 router = fastapi.APIRouter(tags=["rate_limits"])
 
-@router.post("/tier/{name}/rate_limit", dependencies=[Depends(get_current_superuser)], status_code=201)
+@router.post("/tier/{tier_name}/rate_limit", dependencies=[Depends(get_current_superuser)], status_code=201)
 async def write_rate_limit(
     request: Request, 
-    name: str,
+    tier_name: str,
     rate_limit: RateLimitCreate, 
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_tier = await crud_tiers.get(db=db, name=name)
+    db_tier = await crud_tiers.get(db=db, name=tier_name)
     if not db_tier:
         raise HTTPException(status_code=404, detail="Tier not found")
 
@@ -40,15 +40,15 @@ async def write_rate_limit(
     return await crud_rate_limits.create(db=db, object=rate_limit_internal)
 
 
-@router.get("/tier/{name}/rate_limits", response_model=PaginatedListResponse[RateLimitRead])
+@router.get("/tier/{tier_name}/rate_limits", response_model=PaginatedListResponse[RateLimitRead])
 async def read_rate_limits(
     request: Request,
-    name: str,
+    tier_name: str,
     db: Annotated[AsyncSession, Depends(async_get_db)],
     page: int = 1,
     items_per_page: int = 10
 ):
-    db_tier = await crud_tiers.get(db=db, name=name)
+    db_tier = await crud_tiers.get(db=db, name=tier_name)
     if not db_tier:
         raise HTTPException(status_code=404, detail="Tier not found")
 
@@ -90,7 +90,7 @@ async def read_rate_limit(
     return db_rate_limit
 
 
-@router.patch("/tier/{tier_name}/rate_limit/{path}", dependencies=[Depends(get_current_superuser)])
+@router.patch("/tier/{tier_name}/rate_limit/{id}", dependencies=[Depends(get_current_superuser)])
 async def patch_rate_limit(
     request: Request,
     tier_name: str,
@@ -99,11 +99,11 @@ async def patch_rate_limit(
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
     db_tier = await crud_tiers.get(db=db, name=tier_name)
-    if not db_tier:
+    if db_tier is None:
         raise HTTPException(status_code=404, detail="Tier not found")
     
     db_rate_limit = await crud_rate_limits.get(
-        db=db, 
+        db=db,
         schema_to_select=RateLimitRead, 
         tier_id=db_tier["id"],
         id=id
@@ -111,11 +111,19 @@ async def patch_rate_limit(
     if db_rate_limit is None:
         raise HTTPException(status_code=404, detail="Rate Limit not found")
     
+    db_rate_limit_path = await crud_rate_limits.exists(
+        db=db,
+        tier_id=db_tier["id"],
+        path=values.path
+    )
+
+    db_rate_limit_name = await crud_rate_limits.exists(db=db)
+
     await crud_rate_limits.update(db=db, object=values, id=db_rate_limit["id"])
     return {"message": "Rate Limit updated"}
 
 
-@router.delete("/tier/{tier_name}/rate_limit/{path}", dependencies=[Depends(get_current_superuser)])
+@router.delete("/tier/{tier_name}/rate_limit/{id}", dependencies=[Depends(get_current_superuser)])
 async def erase_rate_limit(
     request: Request,
     tier_name: str,

--- a/src/app/api/v1/rate_limits.py
+++ b/src/app/api/v1/rate_limits.py
@@ -1,0 +1,124 @@
+from typing import Annotated
+
+from fastapi import Request, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+import fastapi
+
+from app.schemas.rate_limit import (
+    RateLimitRead,
+    RateLimitCreate,
+    RateLimitCreateInternal,
+    RateLimitUpdate
+)
+from app.api.dependencies import get_current_superuser
+from app.core.database import async_get_db
+from app.crud.crud_rate_limit import crud_rate_limits
+from app.crud.crud_tier import crud_tiers
+from app.api.paginated import PaginatedListResponse, paginated_response, compute_offset
+
+router = fastapi.APIRouter(tags=["rate_limits"])
+
+@router.post("/tier/{tier_id}/rate_limit", dependencies=[Depends(get_current_superuser)], status_code=201)
+async def write_rate_limit(
+    request: Request, 
+    tier_id: int,
+    rate_limit: RateLimitCreate, 
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.exists(db=db, id=tier_id)
+    if not db_tier:
+        raise HTTPException(status_code=404, detail="Tier not found")
+
+    rate_limit_internal_dict = rate_limit.model_dump()
+    rate_limit_internal_dict["tier_id"] = tier_id
+
+    db_rate_limit = await crud_rate_limits.exists(db=db, name=rate_limit_internal_dict["name"])
+    if db_rate_limit:
+        raise HTTPException(status_code=400, detail="Rate Limit Name not available")
+    
+    rate_limit_internal = RateLimitCreateInternal(**rate_limit_internal_dict)
+    return await crud_rate_limits.create(db=db, object=rate_limit_internal)
+
+
+@router.get("/tier/{tier_id}/rate_limits", response_model=PaginatedListResponse[RateLimitRead])
+async def read_rate_limits(
+    request: Request,
+    tier_id: int,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    page: int = 1,
+    items_per_page: int = 10
+):
+    db_tier = await crud_tiers.exists(db=db, id=tier_id)
+    if not db_tier:
+        raise HTTPException(status_code=404, detail="Tier not found")
+
+    rate_limits_data = await crud_rate_limits.get_multi(
+        db=db,
+        offset=compute_offset(page, items_per_page),
+        limit=items_per_page,
+        schema_to_select=RateLimitRead,
+        tier_id=tier_id
+    )
+
+    return paginated_response(
+        crud_data=rate_limits_data, 
+        page=page, 
+        items_per_page=items_per_page
+    )
+
+
+@router.get("/tier/{tier_id}/rate_limit/{id}", response_model=RateLimitRead)
+async def read_rate_limit(
+    request: Request,
+    tier_id: int,
+    id: int, 
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.exists(db=db, id=tier_id)
+    if not db_tier:
+        raise HTTPException(status_code=404, detail="Tier not found")
+    
+    db_rate_limit = await crud_rate_limits.get(db=db, schema_to_select=RateLimitRead, id=id)
+    if db_rate_limit is None:
+        raise HTTPException(status_code=404, detail="Rate Limit not found")
+
+    return db_rate_limit
+
+
+@router.patch("/tier/{tier_id}/rate_limit/{id}", dependencies=[Depends(get_current_superuser)])
+async def patch_rate_limit(
+    request: Request,
+    tier_id: int,
+    id: int,
+    values: RateLimitUpdate,
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.exists(db=db, id=tier_id)
+    if not db_tier:
+        raise HTTPException(status_code=404, detail="Tier not found")
+    
+    db_rate_limit = await crud_rate_limits.get(db=db, schema_to_select=RateLimitRead, id=id)
+    if db_rate_limit is None:
+        raise HTTPException(status_code=404, detail="Rate Limit not found")
+    
+    await crud_rate_limits.update(db=db, object=values, id=id)
+    return {"message": "Rate Limit updated"}
+
+
+@router.delete("/tier/{tier_id}/rate_limit/{id}", dependencies=[Depends(get_current_superuser)])
+async def erase_rate_limit(
+    request: Request,
+    tier_id: int,
+    id: int, 
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.exists(db=db, id=tier_id)
+    if not db_tier:
+        raise HTTPException(status_code=404, detail="Tier not found")
+    
+    db_rate_limit = await crud_rate_limits.get(db=db, schema_to_select=RateLimitRead, id=id)
+    if db_rate_limit is None:
+        raise HTTPException(status_code=404, detail="Rate Limit not found")
+    
+    await crud_rate_limits.delete(db=db, db_row=db_rate_limit, id=id)
+    return {"message": "Rate Limit deleted"}

--- a/src/app/api/v1/tasks.py
+++ b/src/app/api/v1/tasks.py
@@ -1,12 +1,13 @@
 from arq.jobs import Job as ArqJob
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends
 
 from app.core import queue
 from app.schemas.job import Job
+from app.api.dependencies import rate_limiter
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
-@router.post("/task", response_model=Job, status_code=201)
+@router.post("/task", response_model=Job, status_code=201, dependencies=[Depends(rate_limiter)])
 async def create_task(message: str):
     job = await queue.pool.enqueue_job("sample_background_task", message)
     return {"id": job.job_id}

--- a/src/app/api/v1/tasks.py
+++ b/src/app/api/v1/tasks.py
@@ -4,8 +4,7 @@ from fastapi import APIRouter, HTTPException
 from app.core import queue
 from app.schemas.job import Job
 
-router = APIRouter(prefix="/tasks", tags=["Tasks"])
-
+router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 @router.post("/task", response_model=Job, status_code=201)
 async def create_task(message: str):

--- a/src/app/api/v1/tiers.py
+++ b/src/app/api/v1/tiers.py
@@ -1,4 +1,4 @@
-from typing import List, Annotated
+from typing import Annotated
 
 from fastapi import Request, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/app/api/v1/tiers.py
+++ b/src/app/api/v1/tiers.py
@@ -53,43 +53,43 @@ async def read_tiers(
     )
 
 
-@router.get("/tier/{id}", response_model=TierRead)
+@router.get("/tier/{name}", response_model=TierRead)
 async def read_tier(
     request: Request,
-    id: int, 
+    name: str, 
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, id=id)
+    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, name=name)
     if db_tier is None:
         raise HTTPException(status_code=404, detail="Tier not found")
 
     return db_tier
 
 
-@router.patch("/tier/{id}", dependencies=[Depends(get_current_superuser)])
+@router.patch("/tier/{name}", dependencies=[Depends(get_current_superuser)])
 async def patch_tier(
     request: Request, 
     values: TierUpdate,
-    id: int,
+    name: str,
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, id=id)
+    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, name=name)
     if db_tier is None:
         raise HTTPException(status_code=404, detail="Tier not found")
     
-    await crud_tiers.update(db=db, object=values, id=id)
+    await crud_tiers.update(db=db, object=values, name=name)
     return {"message": "Tier updated"}
 
 
-@router.delete("/tier/{id}", dependencies=[Depends(get_current_superuser)])
+@router.delete("/tier/{name}", dependencies=[Depends(get_current_superuser)])
 async def erase_tier(
     request: Request,
-    id: int, 
+    name: str, 
     db: Annotated[AsyncSession, Depends(async_get_db)]
 ):
-    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, id=id)
+    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, name=name)
     if db_tier is None:
         raise HTTPException(status_code=404, detail="Tier not found")
     
-    await crud_tiers.delete(db=db, db_row=db_tier, id=id)
+    await crud_tiers.delete(db=db, db_row=db_tier, name=name)
     return {"message": "Tier deleted"}

--- a/src/app/api/v1/tiers.py
+++ b/src/app/api/v1/tiers.py
@@ -1,0 +1,95 @@
+from typing import List, Annotated
+
+from fastapi import Request, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+import fastapi
+
+from app.schemas.tier import (
+    TierRead,
+    TierCreate,
+    TierCreateInternal,
+    TierUpdate
+)
+from app.api.dependencies import get_current_superuser
+from app.core.database import async_get_db
+from app.crud.crud_tier import crud_tiers
+from app.api.paginated import PaginatedListResponse, paginated_response, compute_offset
+
+router = fastapi.APIRouter(tags=["tiers"])
+
+@router.post("/tier", dependencies=[Depends(get_current_superuser)], status_code=201)
+async def write_tier(
+    request: Request, 
+    tier: TierCreate, 
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):  
+    tier_internal_dict = tier.model_dump()
+    db_tier = await crud_tiers.exists(db=db, name=tier_internal_dict["name"])
+    if db_tier:
+        raise HTTPException(status_code=400, detail="Tier Name not available")
+    
+    tier_internal = TierCreateInternal(**tier_internal_dict)
+    return await crud_tiers.create(db=db, object=tier_internal)
+
+
+@router.get("/tiers", response_model=PaginatedListResponse[TierRead])
+async def read_tiers(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+    page: int = 1,
+    items_per_page: int = 10
+):
+    tiers_data = await crud_tiers.get_multi(
+        db=db,
+        offset=compute_offset(page, items_per_page),
+        limit=items_per_page,
+        schema_to_select=TierRead
+    )
+
+    return paginated_response(
+        crud_data=tiers_data, 
+        page=page, 
+        items_per_page=items_per_page
+    )
+
+
+@router.get("/tier/{id}", response_model=TierRead)
+async def read_tier(
+    request: Request,
+    id: int, 
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, id=id)
+    if db_tier is None:
+        raise HTTPException(status_code=404, detail="Tier not found")
+
+    return db_tier
+
+
+@router.patch("/tier/{id}", dependencies=[Depends(get_current_superuser)])
+async def patch_tier(
+    request: Request, 
+    values: TierUpdate,
+    id: int,
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, id=id)
+    if db_tier is None:
+        raise HTTPException(status_code=404, detail="Tier not found")
+    
+    await crud_tiers.update(db=db, object=values, id=id)
+    return {"message": "Tier updated"}
+
+
+@router.delete("/tier/{id}", dependencies=[Depends(get_current_superuser)])
+async def erase_tier(
+    request: Request,
+    id: int, 
+    db: Annotated[AsyncSession, Depends(async_get_db)]
+):
+    db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, id=id)
+    if db_tier is None:
+        raise HTTPException(status_code=404, detail="Tier not found")
+    
+    await crud_tiers.delete(db=db, db_row=db_tier, id=id)
+    return {"message": "Tier deleted"}

--- a/src/app/core/cache.py
+++ b/src/app/core/cache.py
@@ -298,7 +298,7 @@ def cache(
             formatted_key_prefix = _format_prefix(key_prefix, kwargs)
             cache_key = f"{formatted_key_prefix}:{resource_id}"
             if request.method == "GET":
-                if to_invalidate_extra:
+                if to_invalidate_extra is not None or pattern_to_invalidate_extra is not None:
                     raise InvalidRequestError
 
                 cached_data = await client.get(cache_key)
@@ -318,13 +318,13 @@ def cache(
                 
             else:
                 await client.delete(cache_key)
-                if to_invalidate_extra:
+                if to_invalidate_extra is not None:
                     formatted_extra = _format_extra_data(to_invalidate_extra, kwargs)
                     for prefix, id in formatted_extra.items():
                         extra_cache_key = f"{prefix}:{id}"
                         await client.delete(extra_cache_key)
 
-                if pattern_to_invalidate_extra:
+                if pattern_to_invalidate_extra is not None:
                     for pattern in pattern_to_invalidate_extra:
                         formatted_pattern = _format_prefix(pattern, kwargs)
                         await _delete_keys_by_pattern(formatted_pattern + "*")

--- a/src/app/core/cache.py
+++ b/src/app/core/cache.py
@@ -220,7 +220,6 @@ def cache(
 
                 cached_data = await client.get(cache_key)
                 if cached_data:
-                    print("cache hit")
                     return json.loads(cached_data.decode())
                 
             result = await func(request, *args, **kwargs)

--- a/src/app/core/cache.py
+++ b/src/app/core/cache.py
@@ -151,34 +151,80 @@ def _format_extra_data(
     return formatted_extra
 
 
+async def _delete_keys_by_pattern(pattern: str):
+    """
+    Delete keys from Redis that match a given pattern using the SCAN command.
+
+    This function iteratively scans the Redis key space for keys that match a specific pattern
+    and deletes them. It uses the SCAN command to efficiently find keys, which is more
+    performance-friendly compared to the KEYS command, especially for large datasets.
+
+    The function scans the key space in an iterative manner using a cursor-based approach.
+    It retrieves a batch of keys matching the pattern on each iteration and deletes them
+    until no matching keys are left.
+
+    Parameters
+    ----------
+    pattern: str
+        The pattern to match keys against. The pattern can include wildcards,
+        such as '*' for matching any character sequence. Example: 'user:*'
+
+    Notes
+    -----
+    - The SCAN command is used with a count of 100 to retrieve keys in batches.
+      This count can be adjusted based on the size of your dataset and Redis performance.
+    
+    - The function uses the delete command to remove keys in bulk. If the dataset
+      is extremely large, consider implementing additional logic to handle bulk deletion
+      more efficiently.
+
+    - Be cautious with patterns that could match a large number of keys, as deleting
+      many keys simultaneously may impact the performance of the Redis server.
+    """
+    cursor = "0"
+    while cursor != 0:
+        cursor, keys = await client.scan(cursor, match=pattern, count=100)
+        if keys:
+            await client.delete(*keys)
+
+
 def cache(
         key_prefix: str, 
         resource_id_name: Any = None, 
         expiration: int = 3600, 
         resource_id_type: Union[type, List[type]] = int,
-        to_invalidate_extra: Dict[str, Any] | None = None
+        to_invalidate_extra: Dict[str, Any] | None = None,
+        pattern_to_invalidate_extra: List[str] | None = None
 ) -> Callable:
     """
     Cache decorator for FastAPI endpoints.
 
-    This decorator allows you to cache the results of FastAPI endpoint functions, improving response times and 
-    reducing the load on the application by storing and retrieving data in a cache.
+    This decorator enables caching the results of FastAPI endpoint functions to improve response times 
+    and reduce the load on the application by storing and retrieving data in a cache.
 
     Parameters
     ----------
     key_prefix: str
         A unique prefix to identify the cache key.
-    resource_id: Any, optional
-        The resource ID to be used in cache key generation. If not provided, it will be inferred from the endpoint's keyword arguments.
+    resource_id_name: Any, optional
+        The name of the resource ID argument in the decorated function. If provided, it is used directly; 
+        otherwise, the resource ID is inferred from the function's arguments.
     expiration: int, optional
-        The expiration time for cached data in seconds. Defaults to 3600 seconds (1 hour).
+        The expiration time for the cached data in seconds. Defaults to 3600 seconds (1 hour).
     resource_id_type: Union[type, List[type]], optional
-        The expected type of the resource ID. This can be a single type (e.g., int) or a list of types (e.g., [int, str]). Defaults to int.
+        The expected type of the resource ID. This can be a single type (e.g., int) or a list of types (e.g., [int, str]). 
+        Defaults to int. This is used only if resource_id_name is not provided.
+    to_invalidate_extra: Dict[str, Any] | None, optional
+        A dictionary where keys are cache key prefixes and values are templates for cache key suffixes. 
+        These keys are invalidated when the decorated function is called with a method other than GET.
+    pattern_to_invalidate_extra: List[str] | None, optional
+        A list of string patterns for cache keys that should be invalidated when the decorated function is called. 
+        This allows for bulk invalidation of cache keys based on a matching pattern.
 
     Returns
     -------
     Callable
-        A decorator function that can be applied to FastAPI endpoints.
+        A decorator function that can be applied to FastAPI endpoint functions.
 
     Example usage
     -------------
@@ -200,9 +246,46 @@ def cache(
     This decorator caches the response data of the endpoint function using a unique cache key.
     The cached data is retrieved for GET requests, and the cache is invalidated for other types of requests.
 
+    Advanced Example Usage
+    -------------
+    ```python
+    from fastapi import FastAPI, Request
+    from my_module import cache
+
+    app = FastAPI()
+
+    @app.get("/users/{user_id}/items")
+    @cache(key_prefix="user_items", resource_id_name="user_id", expiration=1200)
+    async def read_user_items(request: Request, user_id: int):
+        # Endpoint logic to fetch user's items
+        return {"items": "user specific items"}
+
+    @app.put("/items/{item_id}")
+    @cache(
+        key_prefix="item_data", 
+        resource_id_name="item_id", 
+        to_invalidate_extra={"user_items": "{user_id}"}, 
+        pattern_to_invalidate_extra=["user_*_items:*"]
+    )
+    async def update_item(request: Request, item_id: int, data: dict, user_id: int):
+        # Update logic for an item
+        # Invalidate both the specific item cache and all user-specific item lists
+        return {"status": "updated"}
+    ```
+
+    In this example:
+    - When reading user items, the response is cached under a key formed with 'user_items' prefix and 'user_id'.
+    - When updating an item, the cache for this specific item (under 'item_data:item_id') and all caches with keys 
+      starting with 'user_{user_id}_items:' are invalidated. The `to_invalidate_extra` parameter specifically targets 
+      the cache for user-specific item lists, while `pattern_to_invalidate_extra` allows bulk invalidation of all keys 
+      matching the pattern 'user_*_items:*', covering all users.
+
     Note
     ----
-        - resource_id_type is used only if resource_id is not passed.
+    - resource_id_type is used only if resource_id is not passed.
+    - `to_invalidate_extra` and `pattern_to_invalidate_extra` are used for cache invalidation on methods other than GET.
+    - Using `pattern_to_invalidate_extra` can be resource-intensive on large datasets. Use it judiciously and
+      consider the potential impact on Redis performance.
     """
     def wrapper(func: Callable) -> Callable:
         @functools.wraps(func)
@@ -240,7 +323,12 @@ def cache(
                     for prefix, id in formatted_extra.items():
                         extra_cache_key = f"{prefix}:{id}"
                         await client.delete(extra_cache_key)
-            
+
+                if pattern_to_invalidate_extra:
+                    for pattern in pattern_to_invalidate_extra:
+                        formatted_pattern = _format_prefix(pattern, kwargs)
+                        await _delete_keys_by_pattern(formatted_pattern + "*")
+
             return result
         
         return inner

--- a/src/app/core/cache.py
+++ b/src/app/core/cache.py
@@ -1,8 +1,6 @@
 from typing import Callable, Union, List, Dict, Any
 import functools
 import json
-from uuid import UUID
-from datetime import datetime
 import re
 
 from fastapi import Request, Response

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -89,6 +89,11 @@ class RedisRateLimiterSettings(BaseSettings):
     REDIS_RATE_LIMIT_URL: str = f"redis://{REDIS_RATE_LIMIT_HOST}:{REDIS_RATE_LIMIT_PORT}"
 
 
+class DefaultRateLimitSettings(BaseSettings):
+    DEFAULT_RATE_LIMIT_LIMIT: int = config("DEFAULT_RATE_LIMIT_LIMIT", default=10)
+    DEFAULT_RATE_LIMIT_PERIOD: int = config("DEFAULT_RATE_LIMIT_PERIOD", default=3600)
+
+
 class EnvironmentOption(Enum):
     LOCAL = "local"
     STAGING = "staging"
@@ -109,6 +114,7 @@ class Settings(
     ClientSideCacheSettings,
     RedisQueueSettings,
     RedisRateLimiterSettings,
+    DefaultRateLimitSettings,
     EnvironmentSettings
 ):
     pass

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -85,9 +85,9 @@ class RedisQueueSettings(BaseSettings):
 
 
 class RedisRateLimiterSettings(BaseSettings):
-    REDIS_RATE_LIMITER_HOST: str = config("REDIS_RATE_LIMITER_HOST", default="localhost")
-    REDIS_RATE_LIMITER_PORT: int = config("REDIS_RATE_LIMITER_PORT", default=6379)
-    REDIS_RATE_LIMITER_URL: str = f"redis://{REDIS_RATE_LIMITER_HOST}:{REDIS_RATE_LIMITER_PORT}"
+    REDIS_RATE_LIMIT_HOST: str = config("REDIS_RATE_LIMIT_HOST", default="localhost")
+    REDIS_RATE_LIMIT_PORT: int = config("REDIS_RATE_LIMIT_PORT", default=6379)
+    REDIS_RATE_LIMIT_URL: str = f"redis://{REDIS_RATE_LIMIT_HOST}:{REDIS_RATE_LIMIT_PORT}"
 
 
 class EnvironmentOption(Enum):

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -1,6 +1,5 @@
 from enum import Enum
 
-#from decouple import config
 from starlette.config import Config
 from pydantic_settings import BaseSettings
 

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -84,6 +84,12 @@ class RedisQueueSettings(BaseSettings):
     REDIS_QUEUE_PORT: str = config("REDIS_QUEUE_PORT", default=6379)
 
 
+class RedisRateLimiterSettings(BaseSettings):
+    REDIS_RATE_LIMITER_HOST: str = config("REDIS_RATE_LIMITER_HOST", default="localhost")
+    REDIS_RATE_LIMITER_PORT: int = config("REDIS_RATE_LIMITER_PORT", default=6379)
+    REDIS_RATE_LIMITER_URL: str = f"redis://{REDIS_RATE_LIMITER_HOST}:{REDIS_RATE_LIMITER_PORT}"
+
+
 class EnvironmentOption(Enum):
     LOCAL = "local"
     STAGING = "staging"
@@ -103,6 +109,7 @@ class Settings(
     RedisCacheSettings,
     ClientSideCacheSettings,
     RedisQueueSettings,
+    RedisRateLimiterSettings,
     EnvironmentSettings
 ):
     pass

--- a/src/app/core/logger.py
+++ b/src/app/core/logger.py
@@ -1,0 +1,20 @@
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+
+LOG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'logs')
+if not os.path.exists(LOG_DIR):
+    os.makedirs(LOG_DIR)
+
+LOG_FILE_PATH = os.path.join(LOG_DIR, 'app.log')
+
+LOGGING_LEVEL = logging.INFO
+LOGGING_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+logging.basicConfig(level=LOGGING_LEVEL, format=LOGGING_FORMAT)
+
+file_handler = RotatingFileHandler(LOG_FILE_PATH, maxBytes=10485760, backupCount=5)
+file_handler.setLevel(LOGGING_LEVEL)
+file_handler.setFormatter(logging.Formatter(LOGGING_FORMAT))
+
+logging.getLogger('').addHandler(file_handler)

--- a/src/app/core/rate_limit.py
+++ b/src/app/core/rate_limit.py
@@ -1,17 +1,45 @@
 from datetime import datetime
-from typing import Union, Dict
 
-from fastapi import HTTPException, Request, Depends, status
 from redis.asyncio import Redis, ConnectionPool
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logger import logging
-from app.schemas.user import UserRead
-from app.schemas.tier import TierRead
-from app.crud.crud_users import crud_users
-
+from app.schemas.rate_limit import sanitize_path
 
 logger = logging.getLogger(__name__)
 
 pool: ConnectionPool | None = None
 client: Redis | None = None
+
+logger = logging.getLogger(__name__)
+
+async def is_rate_limited(
+    db: AsyncSession,
+    user_id: int,
+    path: str,
+    limit: int,
+    period: int
+) -> bool:
+    if client is None:
+        logger.error("Redis client is not initialized.")
+        raise Exception("Redis client is not initialized.")
+
+    current_timestamp = int(datetime.utcnow().timestamp())
+    window_start = current_timestamp - (current_timestamp % period)
+
+    sanitized_path = sanitize_path(path)
+    key = f"ratelimit:{user_id}:{sanitized_path}:{window_start}"
+
+    try:
+        current_count = await client.incr(key)
+        if current_count == 1:
+            await client.expire(key, period)
+
+        if current_count > limit:
+            return True
+
+    except Exception as e:
+        logger.exception(f"Error checking rate limit for user {user_id} on path {path}: {e}")
+        raise e
+
+    return False

--- a/src/app/core/rate_limit.py
+++ b/src/app/core/rate_limit.py
@@ -1,0 +1,9 @@
+import time
+
+from fastapi import HTTPException, Request, Depends, status
+from redis.asyncio import Redis, ConnectionPool
+
+from app.api.dependencies import get_current_user
+
+pool: ConnectionPool | None = None
+client: Redis | None = None

--- a/src/app/core/rate_limit.py
+++ b/src/app/core/rate_limit.py
@@ -1,9 +1,15 @@
-import time
+from datetime import datetime
+from typing import Union, Dict
 
 from fastapi import HTTPException, Request, Depends, status
 from redis.asyncio import Redis, ConnectionPool
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.dependencies import get_current_user
+from app.core.logger import logging
+from app.schemas.user import UserRead
+from app.schemas.tier import TierRead
+
+logger = logging.getLogger(__name__)
 
 pool: ConnectionPool | None = None
 client: Redis | None = None

--- a/src/app/core/rate_limit.py
+++ b/src/app/core/rate_limit.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.logger import logging
 from app.schemas.user import UserRead
 from app.schemas.tier import TierRead
+from app.crud.crud_users import crud_users
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -28,10 +28,10 @@ async def authenticate_user(username_or_email: str, password: str, db: AsyncSess
     else: 
         db_user = await crud_users.get(db=db, username=username_or_email)
     
-    if (not db_user) or (db_user.is_deleted):
+    if (not db_user) or (db_user["is_deleted"]):
         db_user = False
     
-    elif not await verify_password(password, db_user.hashed_password):
+    elif not await verify_password(password, db_user["hashed_password"]):
         db_user = False
     
     return db_user

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -138,7 +138,7 @@ def create_application(router: APIRouter, settings, **kwargs) -> FastAPI:
         application.add_event_handler("shutdown", close_redis_cache_pool)
 
     if isinstance(settings, ClientSideCacheSettings):
-        application.add_middleware(cache.ClientCacheMiddleware, max_age=60)
+        application.add_middleware(cache.ClientCacheMiddleware, max_age=5)
 
     if isinstance(settings, RedisQueueSettings):
         application.add_event_handler("startup", create_redis_queue_pool)

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -138,7 +138,7 @@ def create_application(router: APIRouter, settings, **kwargs) -> FastAPI:
         application.add_event_handler("shutdown", close_redis_cache_pool)
 
     if isinstance(settings, ClientSideCacheSettings):
-        application.add_middleware(cache.ClientCacheMiddleware, max_age=5)
+        application.add_middleware(cache.ClientCacheMiddleware, max_age=settings.CLIENT_CACHE_MAX_AGE)
 
     if isinstance(settings, RedisQueueSettings):
         application.add_event_handler("startup", create_redis_queue_pool)

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -6,6 +6,7 @@ from sqlalchemy import select, update, delete, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.engine.row import Row
 
+from app.core.models import TimestampModel
 from .helper import (
     _extract_matching_columns_from_schema, 
     _extract_matching_columns_from_kwargs
@@ -85,7 +86,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         db_row = await db.execute(stmt)
         result = db_row.first()
         if result:
-            result = result._mapping    
+            result = dict(result._mapping)
         
         return result
     
@@ -217,7 +218,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
             update_data = object
         else:
             update_data = object.model_dump(exclude_unset=True)
-        update_data["updated_at"] = datetime.utcnow()
+        
+        if "updated_at" in update_data.keys():
+            update_data["updated_at"] = datetime.utcnow()
 
         stmt = update(self._model) \
             .filter_by(**kwargs) \

--- a/src/app/crud/crud_rate_limit.py
+++ b/src/app/crud/crud_rate_limit.py
@@ -1,0 +1,12 @@
+from app.crud.crud_base import CRUDBase
+from app.models.rate_limit import RateLimit
+
+from app.schemas.rate_limit import (
+    RateLimitCreateInternal,
+    RateLimitUpdate,
+    RateLimitUpdateInternal,
+    RateLimitDelete
+)
+
+CRUDRateLimit = CRUDBase[RateLimit, RateLimitCreateInternal, RateLimitUpdate, RateLimitUpdateInternal, RateLimitDelete]
+crud_rate_limits = CRUDRateLimit(RateLimit)

--- a/src/app/crud/crud_tier.py
+++ b/src/app/crud/crud_tier.py
@@ -1,0 +1,10 @@
+from app.crud.crud_base import CRUDBase
+from app.models.tier import Tier
+from app.schemas.tier import (
+    TierCreateInternal, 
+    TierUpdate, 
+    TierUpdateInternal, 
+    TierDelete)
+
+CRUDTier = CRUDBase[Tier, TierCreateInternal, TierUpdate, TierUpdateInternal, TierDelete]
+crud_tiers = CRUDTier(Tier)

--- a/src/app/models/post.py
+++ b/src/app/models/post.py
@@ -20,8 +20,6 @@ class Post(Base):
     )
     media_url: Mapped[str | None] = mapped_column(String, default=None)
 
-    user: Mapped["User"] = relationship(back_populates="posts", lazy="selectin", init=False)
-
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default_factory=datetime.utcnow
     )

--- a/src/app/models/rate_limit.py
+++ b/src/app/models/rate_limit.py
@@ -1,18 +1,22 @@
 from typing import Optional
 from datetime import datetime
 
-from sqlalchemy import String, DateTime
+from sqlalchemy import String, DateTime, ForeignKey, Integer
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
 
-class Tier(Base):
-    __tablename__ = "tier"
-
+class RateLimit(Base):
+    __tablename__ = "rate_limit"
+    
     id: Mapped[int] = mapped_column(
         "id", autoincrement=True, nullable=False, unique=True, primary_key=True, init=False
     )
+    tier_id: Mapped[int] = mapped_column(ForeignKey("tier.id"), index=True)
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    path: Mapped[str] = mapped_column(String, nullable=False)
+    limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    period: Mapped[int] = mapped_column(Integer, nullable=False)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default_factory=datetime.utcnow

--- a/src/app/models/tier.py
+++ b/src/app/models/tier.py
@@ -1,0 +1,54 @@
+from typing import Optional, List
+from datetime import datetime
+
+from sqlalchemy import String, DateTime, ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+class RateLimit(Base):
+    __tablename__ = "rate_limit"
+    
+    id: Mapped[int] = mapped_column(
+        "id", autoincrement=True, nullable=False, unique=True, primary_key=True, init=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    path: Mapped[str] = mapped_column(String, nullable=False)
+    limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    period: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    tier_rate_limits: Mapped["TierRateLimit"] = relationship(back_populates="rate_limit", cascade="all, delete", lazy="selectin", default_factory=list)
+
+
+class Tier(Base):
+    __tablename__ = "tier"
+
+    id: Mapped[int] = mapped_column(
+        "id", autoincrement=True, nullable=False, unique=True, primary_key=True, init=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+
+    users: Mapped[List["User"]] = relationship(back_populates="tier", cascade="save-update, merge", lazy="selectin", default_factory=list)
+    tier_rate_limits: Mapped["TierRateLimit"] = relationship(back_populates="tier", cascade="all, delete", lazy="selectin", default_factory=list)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default_factory=datetime.utcnow
+    )
+    updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+
+
+class TierRateLimit(Base):
+    __tablename__ = "tier_rate_limit"
+
+    id: Mapped[int] = mapped_column(
+        "id", autoincrement=True, nullable=False, unique=True, primary_key=True, init=False
+    )
+    
+    rate_limit_id: Mapped[int] = mapped_column(ForeignKey("rate_limit.id"), index=True)
+    tier_id: Mapped[int] = mapped_column(ForeignKey("tier.id"), index=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default_factory=datetime.utcnow
+    ) 
+
+    tier: Mapped[Tier] = relationship(back_populates="tier_rate_limits", init=False)
+    rate_limit: Mapped[RateLimit] = relationship(back_populates="tier_rate_limits", init=False)

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -35,5 +35,3 @@ class User(Base):
 
     tier_id: Mapped[int | None] = mapped_column(ForeignKey("tier.id"), index=True, default=None)
 
-    posts: Mapped[List[Post]] = relationship(back_populates="user", cascade="all, delete", lazy="selectin", default_factory=list)
-    #tier: Mapped[Tier | None] = relationship(back_populates="users", lazy="selectin", default=None)

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -36,4 +36,4 @@ class User(Base):
     tier_id: Mapped[int | None] = mapped_column(ForeignKey("tier.id"), index=True, default=None)
 
     posts: Mapped[List[Post]] = relationship(back_populates="user", cascade="all, delete", lazy="selectin", default_factory=list)
-    tier: Mapped[Tier | None] = relationship(back_populates="users", lazy="selectin", default=None)
+    #tier: Mapped[Tier | None] = relationship(back_populates="users", lazy="selectin", default=None)

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -2,11 +2,12 @@ from typing import Optional, List
 import uuid as uuid_pkg
 from datetime import datetime
 
-from sqlalchemy import String, DateTime
+from sqlalchemy import String, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
 from app.models.post import Post
+from app.models.tier import Tier
 
 class User(Base):
     __tablename__ = "user"
@@ -32,4 +33,7 @@ class User(Base):
     is_deleted: Mapped[bool] = mapped_column(default=False, index=True)
     is_superuser: Mapped[bool] = mapped_column(default=False)
 
+    tier_id: Mapped[int | None] = mapped_column(ForeignKey("tier.id"), index=True, default=None)
+
     posts: Mapped[List[Post]] = relationship(back_populates="user", cascade="all, delete", lazy="selectin", default_factory=list)
+    tier: Mapped[Tier | None] = relationship(back_populates="users", lazy="selectin", default=None)

--- a/src/app/schemas/rate_limit.py
+++ b/src/app/schemas/rate_limit.py
@@ -1,9 +1,13 @@
 from typing import Annotated
 from datetime import datetime
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, validator
 
 from app.core.models import TimestampModel
+
+def sanitize_path(path: str) -> str:
+    return path.strip("/").replace("/", "_")
+
 
 class RateLimitBase(BaseModel):
     path: Annotated[
@@ -18,6 +22,10 @@ class RateLimitBase(BaseModel):
         int,
         Field(examples=[60])
     ]
+
+    @validator('path', pre=True, always=True)
+    def validate_and_sanitize_path(cls, value: str) -> str:
+        return sanitize_path(value)
 
 
 class RateLimit(TimestampModel, RateLimitBase):
@@ -58,6 +66,10 @@ class RateLimitUpdate(BaseModel):
     limit: int | None = None
     period: int | None = None
     name: str | None = None
+
+    @validator('path', pre=True, allow_reuse=True)
+    def validate_and_sanitize_path(cls, value: str) -> str:
+        return sanitize_path(value)
 
 
 class RateLimitUpdateInternal(RateLimitUpdate):

--- a/src/app/schemas/rate_limit.py
+++ b/src/app/schemas/rate_limit.py
@@ -1,0 +1,67 @@
+from typing import Annotated
+from datetime import datetime
+
+from pydantic import BaseModel, Field, ConfigDict
+
+from app.core.models import TimestampModel
+
+class RateLimitBase(BaseModel):
+    path: Annotated[
+        str, 
+        Field(examples=["/users"])
+    ]
+    limit: Annotated[
+        int,
+        Field(examples=[5])
+    ]
+    period: Annotated[
+        int,
+        Field(examples=[60])
+    ]
+
+
+class RateLimit(TimestampModel, RateLimitBase):
+    tier_id: int
+    name: Annotated[
+        str | None,
+        Field(
+            default=None,
+            examples=["/users:5:60"]
+        )
+    ]
+
+
+class RateLimitRead(RateLimitBase):
+    id: int
+    name: str
+
+
+class RateLimitCreate(RateLimitBase):
+    model_config = ConfigDict(extra='forbid')
+    
+    name: Annotated[
+        str | None,
+        Field(
+            default=None,
+            examples=["/users:5:60"]
+        )
+    ]
+
+
+class RateLimitCreateInternal(RateLimitCreate):
+    tier_id: int
+
+
+class RateLimitUpdate(BaseModel):
+    path: str | None = None
+    limit: int | None = None
+    period: int | None = None
+    name: str | None = None
+
+
+class RateLimitUpdateInternal(RateLimitUpdate):
+    updated_at: datetime
+
+
+class RateLimitDelete(BaseModel):
+    pass

--- a/src/app/schemas/rate_limit.py
+++ b/src/app/schemas/rate_limit.py
@@ -8,7 +8,7 @@ from app.core.models import TimestampModel
 class RateLimitBase(BaseModel):
     path: Annotated[
         str, 
-        Field(examples=["/users"])
+        Field(examples=["users"])
     ]
     limit: Annotated[
         int,
@@ -26,13 +26,14 @@ class RateLimit(TimestampModel, RateLimitBase):
         str | None,
         Field(
             default=None,
-            examples=["/users:5:60"]
+            examples=["users:5:60"]
         )
     ]
 
 
 class RateLimitRead(RateLimitBase):
     id: int
+    tier_id: int
     name: str
 
 
@@ -43,7 +44,7 @@ class RateLimitCreate(RateLimitBase):
         str | None,
         Field(
             default=None,
-            examples=["/users:5:60"]
+            examples=["api_v1_users:5:60"]
         )
     ]
 

--- a/src/app/schemas/tier.py
+++ b/src/app/schemas/tier.py
@@ -1,0 +1,123 @@
+from typing import Annotated
+from datetime import datetime
+
+from pydantic import BaseModel, Field, ConfigDict
+
+from app.core.models import TimestampModel
+
+# -------------- Rate Limit --------------
+class RateLimitBase(BaseModel):
+    path: Annotated[
+        str, 
+        Field(examples=["/users"])
+    ]
+    limit: Annotated[
+        int,
+        Field(examples=[5])
+    ]
+    period: Annotated[
+        int,
+        Field(example=[60])
+    ]
+    name: Annotated[
+        str | None,
+        Field(
+            default=None,
+            examples=["/users:5:60"]
+        )
+    ]
+
+
+class RateLimit(TimestampModel, RateLimitBase):
+    pass
+
+
+class RateLimitRead(RateLimitBase):
+    id: int
+
+
+class RateLimitCreate(RateLimitBase):
+    model_config = ConfigDict(extra='forbid')
+
+
+class RateLimitCreateInternal(RateLimitCreate):
+    pass
+
+
+class RateLimitUpdate(BaseModel):
+    pass
+
+
+class RateLimitDelete(BaseModel):
+    pass
+
+# -------------- Tier --------------
+class TierBase(BaseModel):
+    name: Annotated[
+        str, 
+        Field(examples=["free"])
+    ]
+
+
+class Tier(TimestampModel, TierBase):
+    pass
+
+
+class TierRead(TierBase):
+    id: int
+    created_at: datetime
+
+
+class TierCreate(TierBase):
+    pass
+
+
+class TierCreateInternal(TierCreate):
+    pass
+
+
+class TierUpdate(BaseModel):
+    name: str | None = None
+
+
+class TierUpdateInternal(TierUpdate):
+    updated_at: datetime
+
+
+class TierDelete(BaseModel):
+    pass
+
+
+# -------------- Tier Rate Limit --------------
+class TierRateLimitBase(BaseModel):
+    rate_limit_id: int
+    tier_id: int
+
+
+class TierRateLimit(TimestampModel, TierRateLimitBase):
+    id: int
+    created_at: datetime
+
+
+class TierRateLimitRead(TierRateLimitBase):
+    pass
+
+
+class TierRateLimitCreate(TierRateLimitBase):
+    pass
+
+
+class TierRateLimitCreateInternal(TierRateLimitCreate):
+    pass
+
+
+class TierRateLimitUpdate(BaseModel):
+    pass
+
+
+class TierRateLimitUpdateInternal(TierRateLimitUpdate):
+    pass
+
+
+class TierRateLimitDelete(BaseModel):
+    pass

--- a/src/app/schemas/tier.py
+++ b/src/app/schemas/tier.py
@@ -1,57 +1,10 @@
 from typing import Annotated
 from datetime import datetime
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field
 
 from app.core.models import TimestampModel
 
-# -------------- Rate Limit --------------
-class RateLimitBase(BaseModel):
-    path: Annotated[
-        str, 
-        Field(examples=["/users"])
-    ]
-    limit: Annotated[
-        int,
-        Field(examples=[5])
-    ]
-    period: Annotated[
-        int,
-        Field(example=[60])
-    ]
-    name: Annotated[
-        str | None,
-        Field(
-            default=None,
-            examples=["/users:5:60"]
-        )
-    ]
-
-
-class RateLimit(TimestampModel, RateLimitBase):
-    pass
-
-
-class RateLimitRead(RateLimitBase):
-    id: int
-
-
-class RateLimitCreate(RateLimitBase):
-    model_config = ConfigDict(extra='forbid')
-
-
-class RateLimitCreateInternal(RateLimitCreate):
-    pass
-
-
-class RateLimitUpdate(BaseModel):
-    pass
-
-
-class RateLimitDelete(BaseModel):
-    pass
-
-# -------------- Tier --------------
 class TierBase(BaseModel):
     name: Annotated[
         str, 
@@ -85,39 +38,4 @@ class TierUpdateInternal(TierUpdate):
 
 
 class TierDelete(BaseModel):
-    pass
-
-
-# -------------- Tier Rate Limit --------------
-class TierRateLimitBase(BaseModel):
-    rate_limit_id: int
-    tier_id: int
-
-
-class TierRateLimit(TimestampModel, TierRateLimitBase):
-    id: int
-    created_at: datetime
-
-
-class TierRateLimitRead(TierRateLimitBase):
-    pass
-
-
-class TierRateLimitCreate(TierRateLimitBase):
-    pass
-
-
-class TierRateLimitCreateInternal(TierRateLimitCreate):
-    pass
-
-
-class TierRateLimitUpdate(BaseModel):
-    pass
-
-
-class TierRateLimitUpdateInternal(TierRateLimitUpdate):
-    pass
-
-
-class TierRateLimitDelete(BaseModel):
     pass

--- a/src/app/schemas/user.py
+++ b/src/app/schemas/user.py
@@ -106,6 +106,10 @@ class UserUpdateInternal(UserUpdate):
     updated_at: datetime
 
 
+class UserTierUpdate(BaseModel):
+    tier_id: int
+
+
 class UserDelete(BaseModel):
     model_config = ConfigDict(extra='forbid')
 

--- a/src/app/schemas/user.py
+++ b/src/app/schemas/user.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Optional
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field, HttpUrl, ConfigDict
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 
 from app.core.models import UUIDModel, TimestampModel, PersistentDeletion
 
@@ -27,10 +27,13 @@ class User(TimestampModel, UserBase, UUIDModel, PersistentDeletion):
     ]
     hashed_password: str
     is_superuser: bool = False
+    tier_id: int | None = None
 
 
 class UserRead(BaseModel):
     id: int
+    tier_id: int
+    
     name: Annotated[
         str, 
         Field(min_length=2, max_length=30, examples=["User Userson"])
@@ -44,6 +47,7 @@ class UserRead(BaseModel):
         Field(examples=["user.userson@example.com"])
     ]
     profile_image_url: str
+    tier_id: int | None
 
 
 class UserCreate(UserBase):

--- a/src/scripts/create_first_tier.py
+++ b/src/scripts/create_first_tier.py
@@ -1,0 +1,28 @@
+import asyncio
+from sqlalchemy import select
+from app.core.config import config
+
+from app.core.database import AsyncSession, local_session
+from app.models.tier import Tier
+
+async def create_first_tier(session: AsyncSession) -> None:
+    tier_name = config("TIER_NAME", default="free")
+    
+    query = select(Tier).where(Tier.name == tier_name)
+    result = await session.execute(query)
+    tier = result.scalar_one_or_none()
+    
+    if tier is None:
+        session.add(
+            Tier(name=tier_name)
+        )
+        
+        await session.commit()
+
+async def main():
+    async with local_session() as session:
+        await create_first_tier(session)
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())


### PR DESCRIPTION
## Summary

###  🚀Features
- `rate_limiter` dependency created 🛑
- cache now supports `pattern_to_invalidate_extra` 🏬
- logger file created to handle logging (used with rate_limiter) 🐛

### 📝Docs

#### 0. New Tier and Rate Limit models
![diagram](https://user-images.githubusercontent.com/43156212/282272311-c7a36e26-dcd0-42cf-939d-6434b5579f29.png)
To allow fully customizable tier creation and rate limiting, new models, schemas and crud objects were created.

#### 1. Rate Limiting
To limit how many times a user can make a request in a certain interval of time (very useful to create subscription plans or just to protect your API against DDOS), you may just use the `rate_limiter` dependency:

```python
from fastapi import Depends

from app.api.dependencies import rate_limiter
from app.core import queue
from app.schemas.job import Job

@router.post("/task", response_model=Job, status_code=201, dependencies=[Depends(rate_limiter)])
async def create_task(message: str):
    job = await queue.pool.enqueue_job("sample_background_task", message)
    return {"id": job.job_id}
```

By default, if no token is passed in the header (that is - the user is not authenticated), the user will be limited by his IP address with the default `limit` (how many times the user can make this request every period) and `period` (time in seconds) defined in `.env`.

Even though this is useful, real power comes from creating `tiers` (categories of users) and standard `rate_limits` (`limits` and `periods` defined for specific `paths` - that is - endpoints) for these tiers. 

All of the `tier` and `rate_limit` models, schemas, and endpoints are already created in the respective folders (and usable only by superusers). You may use the `create_tier` script to create the first tier (it uses the `.env` variable `TIER_NAME`, which is all you need to create a tier) or just use the api:

Here I'll create a `free` tier:

<p align="left">
    <img src="https://user-images.githubusercontent.com/43156212/282275103-d9c4f511-4cfa-40c6-b882-5b09df9f62b9.png" alt="passing name = free to api request body" width="70%" height="auto">
</p>

And a `pro` tier:

<p align="left">
    <img src="https://user-images.githubusercontent.com/43156212/282275107-5a6ca593-ccc0-4965-b2db-09ec5ecad91c.png" alt="passing name = pro to api request body" width="70%" height="auto">
</p>

Then I'll associate a `rate_limit` for the path `api/v1/tasks/task` for each of them, I'll associate a `rate limit` for the path `api/v1/tasks/task`. 

1 request every hour (3600 seconds) for the free tier: 

<p align="left">
    <img src="https://user-images.githubusercontent.com/43156212/282275105-95d31e19-b798-4f03-98f0-3e9d1844f7b3.png" alt="passing path=api/v1/tasks/task, limit=1, period=3600, name=api_v1_tasks:1:3600 to free tier rate limit" width="70%" height="auto">
</p>

10 requests every hour for the pro tier:

<p align="left">
    <img src="https://user-images.githubusercontent.com/43156212/282275108-deec6f46-9d47-4f01-9899-ca42da0f0363.png" alt="passing path=api/v1/tasks/task, limit=10, period=3600, name=api_v1_tasks:10:3600 to pro tier rate limit" width="70%" height="auto">
</p>

Now let's read all the tiers available (`GET api/v1/tiers`): 

```javascript
{
  "data": [
    {
      "name": "free",
      "id": 1,
      "created_at": "2023-11-11T05:57:25.420360"
    },
    {
      "name": "pro",
      "id": 2,
      "created_at": "2023-11-12T00:40:00.759847"
    }
  ],
  "total_count": 2,
  "has_more": false,
  "page": 1,
  "items_per_page": 10
}
```

And read the `rate_limits` for the `pro` tier to ensure it's working (`GET api/v1/tier/pro/rate_limits`):

```javascript
{
  "data": [
    {
      "path": "api_v1_tasks_task",
      "limit": 10,
      "period": 3600,
      "id": 1,
      "tier_id": 2,
      "name": "api_v1_tasks:10:3600"
    }
  ],
  "total_count": 1,
  "has_more": false,
  "page": 1,
  "items_per_page": 10
}
```

Now, whenever an authenticated user makes a `POST` request to the `api/v1/tasks/task`, they'll use the quota that is defined by their tier. 
You may check this getting the token from the `api/v1/login` endpoint, then passing it in the request header:
```sh
curl -X POST 'http://127.0.0.1:8000/api/v1/tasks/task?message=test' \
-H 'Authorization: Bearer <your-token-here>'
```

> **Warning**
> Since the `rate_limiter` dependency uses the `get_optional_user` dependency instead of `get_current_user`, it will not require authentication to be used, but will behave accordingly if the user is authenticated (and token is passed in header). If you want to ensure authentication, also use `get_current_user` if you need.

To change a user's tier, you may just use the `PATCH api/v1/user/{username}/tier` endpoint.
Note that for flexibility (since this is a boilerplate), it's not necessary to previously inform a tier_id to create a user, but you probably should set every user to a certain tier (let's say `free`) once they are created. 

> **Warning**
> If a user does not have a `tier` or the tier does not have a defined `rate limit` for the path and the token is still passed to the request, the default `limit` and `period` will be used, this will be saved in `app/logs`.

#### 2. Cache Pattern Invalidation 

Let's assume we have an endpoint with a paginated response, such as:
```python
@router.get("/{username}/posts", response_model=PaginatedListResponse[PostRead])
@cache(
    key_prefix="{username}_posts:page_{page}:items_per_page:{items_per_page}", 
    resource_id_name="username",
    expiration=60
)
async def read_posts(
    request: Request,
    username: str,
    db: Annotated[AsyncSession, Depends(async_get_db)],
    page: int = 1,
    items_per_page: int = 10
):
    db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
    if not db_user:
        raise HTTPException(status_code=404, detail="User not found")

    posts_data = await crud_posts.get_multi(
        db=db,
        offset=compute_offset(page, items_per_page),
        limit=items_per_page,
        schema_to_select=PostRead,
        created_by_user_id=db_user["id"],
        is_deleted=False
    )

    return paginated_response(
        crud_data=posts_data, 
        page=page, 
        items_per_page=items_per_page
    )
```

Just passing `to_invalidate_extra` will not work to invalidate this cache, since the key will change based on the `page` and `items_per_page` values.
To overcome this we may use the `pattern_to_invalidate_extra` parameter:

```python
@router.patch("/{username}/post/{id}")
@cache(
    "{username}_post_cache", 
    resource_id_name="id", 
    pattern_to_invalidate_extra=["{username}_posts:*"]
)
async def patch_post(
    request: Request,
    username: str,
    id: int,
    values: PostUpdate,
    current_user: Annotated[UserRead, Depends(get_current_user)],
    db: Annotated[AsyncSession, Depends(async_get_db)]
):
...
```

Now it will invalidate all caches with a key that matches the pattern `"{username}_posts:*`, which will work for the paginated responses.

> **Warning**
> Using `pattern_to_invalidate_extra` can be resource-intensive on large datasets. Use it judiciously and consider the potential impact on Redis performance. Be cautious with patterns that could match a large number of keys, as deleting many keys simultaneously may impact the performance of the Redis server.


### 🚚Migration
- Run alembic migrations to create the new models/relationships
- To use rate limiting, you may just add the dependency as documented
- previous cache usage will continue working, but now the option to `pattern_to_invalidate_extra` will also allow you to invalidate paginated responses cache

> **Warning**
> What's retrieved from the **get** and **get multi** methods is no longer a `sqlalchemy.engine.row.Row`, is a python `dict` instead. Attributes should be accessed with object["attribute_name"] instead of object.attribute_name

###  🔎Bug fixes

- custom client side cache expiration now working
- now it's possible to invalidate cached data of paginated responses