### PR TITLE
Token refresh

### DIFF
--- a/src/app/api/v1/logout.py
+++ b/src/app/api/v1/logout.py
@@ -1,8 +1,6 @@
 from typing import Dict
 
-from datetime import datetime
-
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Response, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from jose import JWTError
 
@@ -14,11 +12,14 @@ router = APIRouter(tags=["login"])
 
 @router.post("/logout")
 async def logout(
-    token: str = Depends(oauth2_scheme),
+    response: Response,
+    access_token: str = Depends(oauth2_scheme),
     db: AsyncSession = Depends(async_get_db)
 ) -> Dict[str, str]:
     try:
-        await blacklist_token(token=token, db=db)
+        await blacklist_token(token=access_token, db=db)
+        response.delete_cookie(key="refresh_token")
+
         return {"message": "Logged out successfully"}
     
     except JWTError:

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -16,8 +16,9 @@ class AppSettings(BaseSettings):
 
 class CryptSettings(BaseSettings):
     SECRET_KEY: str = config("SECRET_KEY")
-    ALGORITHM: str = config("ALGORITHM")
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = config("ACCESS_TOKEN_EXPIRE_MINUTES")
+    ALGORITHM: str = config("ALGORITHM", default="HS256")
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = config("ACCESS_TOKEN_EXPIRE_MINUTES", default=30)
+    REFRESH_TOKEN_EXPIRE_DAYS: int = config("REFRESH_TOKEN_EXPIRE_DAYS", default=7)
 
 
 class DatabaseSettings(BaseSettings):

--- a/src/app/core/db/models.py
+++ b/src/app/core/db/models.py
@@ -11,6 +11,7 @@ class TimestampMixin:
     created_at: datetime = Column(DateTime, default=datetime.utcnow, server_default=text("current_timestamp(0)"))
     updated_at: datetime = Column(DateTime, nullable=True, onupdate=datetime.utcnow, server_default=text("current_timestamp(0)"))
 
+
 class SoftDeleteMixin:
     deleted_at: datetime = Column(DateTime, nullable=True)
     is_deleted: bool = Column(Boolean, default=False)

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -14,6 +14,7 @@ from app.crud.crud_users import crud_users
 SECRET_KEY = settings.SECRET_KEY
 ALGORITHM = settings.ALGORITHM
 ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
+REFRESH_TOKEN_EXPIRE_DAYS = settings.REFRESH_TOKEN_EXPIRE_DAYS
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/login")
 crypt_context = CryptContext(schemes=["sha256_crypt"])
@@ -46,6 +47,16 @@ async def create_access_token(data: dict[str, Any], expires_delta: timedelta | N
         expire = datetime.utcnow() + expires_delta
     else:
         expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+async def create_refresh_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire})
     encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt


### PR DESCRIPTION
### 🔐JWT Authentication With Refresh Token
#### Details
The JWT in the boilerplate was updated to work in the following way:
1. **JWT Access Tokens:** how you actually access protected resources is passing this token in the request header.
2. **Refresh Tokens:** you use this type of token to get an `access token`, which you'll use to access protected resources. 

The `access token` is short lived (default 30 minutes) to reduce the damage of a potential leak. The `refresh token`, on the other hand, is long lived (default 7 days), and you use it to renew your `access token` without the need to provide username and password every time it expires.

Since the `refresh token` lasts for a longer time, it's stored as a cookie in a secure way:

```python
# app/api/v1/login

...
response.set_cookie(
    key="refresh_token",
    value=refresh_token,
    httponly=True,               # Prevent access through JavaScript
    secure=True,                 # Ensure cookie is sent over HTTPS only
    samesite='Lax',              # Default to Lax for reasonable balance between security and usability
    max_age=<number_of_seconds>  # Set a max age for the cookie
)
...
```

You may change it to suit your needs. The possible options for `samesite` are:
- `Lax`: Cookies will be sent in top-level navigations (like clicking on a link to go to another site), but not in API requests or images loaded from other sites.
- `Strict`: Cookies will be sent in top-level navigations (like clicking on a link to go to another site), but not in API requests or images loaded from other sites.
- `None`: Cookies will be sent with both same-site and cross-site requests.

####  🚀Usage
What you should do with the client is:
- `Login`: Send credentials to `/api/v1/login`. Store the returned access token in memory for subsequent requests.
- `Accessing Protected Routes`: Include the access token in the Authorization header.
- `Token Renewal`: On access token expiry, the front end should automatically call `/api/v1/refresh` for a new token.
- `Login Again`: If refresh token is expired, credentials should be sent to `/api/v1/login` again, storing the new access token in memory.
- `Logout`: Call /api/v1/logout to end the session securely.

This authentication setup in the provides a robust, secure, and user-friendly way to handle user sessions in your API applications.
