### PR TITLE
passlib replaced with bcrypt for password hashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ alembic = "^1.12.0"
 asyncpg = "^0.28.0"
 SQLAlchemy-Utils = "^0.41.1"
 python-jose = "^3.3.0"
-passlib = "^1.7.4"
 SQLAlchemy = "^2.0.21"
 pytest = "^7.4.2"
 python-multipart = "^0.0.6"
@@ -30,6 +29,7 @@ pydantic-settings = "^2.0.3"
 redis = "^5.0.1"
 arq = "^0.25.0"
 gunicorn = "^21.2.0"
+bcrypt = "^4.1.1"
 
 
 [build-system]

--- a/src/app/api/dependencies.py
+++ b/src/app/api/dependencies.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Union, Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from jose import JWTError, jwt
 from fastapi import (
     Depends, 
     HTTPException, 
@@ -13,7 +12,6 @@ from ..core.config import settings
 from ..core.exceptions.http_exceptions import UnauthorizedException, ForbiddenException, RateLimitException
 from ..core.db.database import async_get_db
 from ..core.logger import logging
-from ..core.schemas import TokenData
 from ..core.utils.rate_limit import is_rate_limited
 from ..core.security import verify_token
 from ..crud.crud_rate_limit import crud_rate_limits

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -1,8 +1,8 @@
 from typing import Union, Literal, Dict, Any
 from datetime import datetime, timedelta
 
+import bcrypt
 from sqlalchemy.ext.asyncio import AsyncSession
-from passlib.context import CryptContext
 from jose import jwt, JWTError
 from fastapi.security import OAuth2PasswordBearer
 
@@ -17,15 +17,12 @@ ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 REFRESH_TOKEN_EXPIRE_DAYS = settings.REFRESH_TOKEN_EXPIRE_DAYS
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/login")
-crypt_context = CryptContext(schemes=["sha256_crypt"])
 
 async def verify_password(plain_password: str, hashed_password: str) -> bool:
-    out: bool = crypt_context.verify(plain_password, hashed_password)
-    return out
+    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
 
 def get_password_hash(password: str) -> str:
-    out: str = crypt_context.hash(password)
-    return out
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 async def authenticate_user(username_or_email: str, password: str, db: AsyncSession) -> Union[Dict[str, Any], Literal[False]]:
     if "@" in username_or_email:


### PR DESCRIPTION
Closes #2 

Warning `passlib - DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13` no longer being raised in tests.