### PR TITLE
Refactor datetime.utcnow() to datetime.now(timezone.utc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ crud_users.update(db=db, object={name="Updated Name"}, username="myusername")
 To delete we have two options:
 - db_delete: actually deletes the row from the database
 - delete: 
-    - adds `"is_deleted": True` and `deleted_at: datetime.utcnow()` if the model inherits from `PersistentDeletion` (performs a soft delete), but keeps the object in the database.
+    - adds `"is_deleted": True` and `deleted_at: datetime.now(timezone.utc)` if the model inherits from `PersistentDeletion` (performs a soft delete), but keeps the object in the database.
     - actually deletes the row from the database if the model does not inherit from `PersistentDeletion`
 
 ```python

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ crud_users.update(db=db, object={name="Updated Name"}, username="myusername")
 To delete we have two options:
 - db_delete: actually deletes the row from the database
 - delete: 
-    - adds `"is_deleted": True` and `deleted_at: datetime.now(timezone.utc)` if the model inherits from `PersistentDeletion` (performs a soft delete), but keeps the object in the database.
+    - adds `"is_deleted": True` and `deleted_at: datetime.now(UTC)` if the model inherits from `PersistentDeletion` (performs a soft delete), but keeps the object in the database.
     - actually deletes the row from the database if the model does not inherit from `PersistentDeletion`
 
 ```python

--- a/src/app/core/db/models.py
+++ b/src/app/core/db/models.py
@@ -1,5 +1,5 @@
 import uuid as uuid_pkg
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, Boolean, text
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -8,8 +8,8 @@ class UUIDMixin:
 
 
 class TimestampMixin:
-    created_at: datetime = Column(DateTime, default=datetime.utcnow, server_default=text("current_timestamp(0)"))
-    updated_at: datetime = Column(DateTime, nullable=True, onupdate=datetime.utcnow, server_default=text("current_timestamp(0)"))
+    created_at: datetime = Column(DateTime, default=datetime.now(timezone.utc), server_default=text("current_timestamp(0)"))
+    updated_at: datetime = Column(DateTime, nullable=True, onupdate=datetime.now(timezone.utc), server_default=text("current_timestamp(0)"))
 
 
 class SoftDeleteMixin:

--- a/src/app/core/db/models.py
+++ b/src/app/core/db/models.py
@@ -1,5 +1,5 @@
 import uuid as uuid_pkg
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from sqlalchemy import Column, DateTime, Boolean, text
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -8,8 +8,8 @@ class UUIDMixin:
 
 
 class TimestampMixin:
-    created_at: datetime = Column(DateTime, default=datetime.now(timezone.utc), server_default=text("current_timestamp(0)"))
-    updated_at: datetime = Column(DateTime, nullable=True, onupdate=datetime.now(timezone.utc), server_default=text("current_timestamp(0)"))
+    created_at: datetime = Column(DateTime, default=datetime.now(UTC), server_default=text("current_timestamp(0)"))
+    updated_at: datetime = Column(DateTime, nullable=True, onupdate=datetime.now(UTC), server_default=text("current_timestamp(0)"))
 
 
 class SoftDeleteMixin:

--- a/src/app/core/schemas.py
+++ b/src/app/core/schemas.py
@@ -1,6 +1,6 @@
 from typing import Any
 import uuid as uuid_pkg
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -15,7 +15,7 @@ class UUIDSchema(BaseModel):
 
 
 class TimestampSchema(BaseModel):
-    created_at: datetime = Field(default_factory=lambda:  datetime.now(timezone.utc).replace(tzinfo=None))
+    created_at: datetime = Field(default_factory=lambda:  datetime.now(UTC).replace(tzinfo=None))
     updated_at: datetime = Field(default=None)
 
     @field_serializer("created_at")

--- a/src/app/core/schemas.py
+++ b/src/app/core/schemas.py
@@ -1,6 +1,6 @@
 from typing import Any
 import uuid as uuid_pkg
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -15,7 +15,7 @@ class UUIDSchema(BaseModel):
 
 
 class TimestampSchema(BaseModel):
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda:  datetime.now(timezone.utc).replace(tzinfo=None))
     updated_at: datetime = Field(default=None)
 
     @field_serializer("created_at")

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -1,5 +1,5 @@
 from typing import Union, Literal, Dict, Any
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import bcrypt
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,9 +41,9 @@ async def authenticate_user(username_or_email: str, password: str, db: AsyncSess
 async def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
+        expire = datetime.now(UTC).replace(tzinfo=None) + expires_delta
     else:
-        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+        expire = datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
@@ -51,9 +51,9 @@ async def create_access_token(data: dict[str, Any], expires_delta: timedelta | N
 async def create_refresh_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.now(timezone.utc) + expires_delta
+        expire = datetime.now(UTC).replace(tzinfo=None) + expires_delta
     else:
-        expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+        expire = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire})
     encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -1,5 +1,5 @@
 from typing import Union, Literal, Dict, Any
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import bcrypt
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -41,9 +41,9 @@ async def authenticate_user(username_or_email: str, password: str, db: AsyncSess
 async def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
@@ -51,9 +51,9 @@ async def create_access_token(data: dict[str, Any], expires_delta: timedelta | N
 async def create_refresh_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+        expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire})
     encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/src/app/core/utils/rate_limit.py
+++ b/src/app/core/utils/rate_limit.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from redis.asyncio import Redis, ConnectionPool
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,7 +22,7 @@ async def is_rate_limited(
         logger.error("Redis client is not initialized.")
         raise Exception("Redis client is not initialized.")
 
-    current_timestamp = int(datetime.now(timezone.utc).timestamp())
+    current_timestamp = int(datetime.now(UTC).timestamp())
     window_start = current_timestamp - (current_timestamp % period)
 
     sanitized_path = sanitize_path(path)

--- a/src/app/core/utils/rate_limit.py
+++ b/src/app/core/utils/rate_limit.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from redis.asyncio import Redis, ConnectionPool
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,7 +22,7 @@ async def is_rate_limited(
         logger.error("Redis client is not initialized.")
         raise Exception("Redis client is not initialized.")
 
-    current_timestamp = int(datetime.utcnow().timestamp())
+    current_timestamp = int(datetime.now(timezone.utc).timestamp())
     window_start = current_timestamp - (current_timestamp % period)
 
     sanitized_path = sanitize_path(path)

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, Generic, List, Type, TypeVar, Union
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel
 from sqlalchemy import select, update, delete, func, and_, inspect
@@ -441,7 +441,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
             update_data = object.model_dump(exclude_unset=True)
         
         if "updated_at" in update_data.keys():
-            update_data["updated_at"] = datetime.utcnow()
+            update_data["updated_at"] = datetime.now(timezone.utc)
 
         stmt = update(self._model) \
             .filter_by(**kwargs) \
@@ -500,7 +500,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
             if "is_deleted" in self._model.__table__.columns:
                 object_dict = {
                     "is_deleted": True,
-                    "deleted_at": datetime.utcnow()
+                    "deleted_at": datetime.now(timezone.utc)
                 }
                 stmt = update(self._model) \
                     .filter_by(**kwargs) \

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, Generic, List, Type, TypeVar, Union
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from pydantic import BaseModel
 from sqlalchemy import select, update, delete, func, and_, inspect
@@ -441,7 +441,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
             update_data = object.model_dump(exclude_unset=True)
         
         if "updated_at" in update_data.keys():
-            update_data["updated_at"] = datetime.now(timezone.utc)
+            update_data["updated_at"] = datetime.now(UTC)
 
         stmt = update(self._model) \
             .filter_by(**kwargs) \
@@ -500,7 +500,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
             if "is_deleted" in self._model.__table__.columns:
                 object_dict = {
                     "is_deleted": True,
-                    "deleted_at": datetime.now(timezone.utc)
+                    "deleted_at": datetime.now(UTC)
                 }
                 stmt = update(self._model) \
                     .filter_by(**kwargs) \

--- a/src/app/models/post.py
+++ b/src/app/models/post.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import uuid as uuid_pkg
 from datetime import datetime, UTC
 
@@ -23,6 +24,6 @@ class Post(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
-    updated_at: Mapped[datetime | None] = mapped_column(default=None)
-    deleted_at: Mapped[datetime | None] = mapped_column(default=None)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)
     is_deleted: Mapped[bool] = mapped_column(default=False, index=True)

--- a/src/app/models/post.py
+++ b/src/app/models/post.py
@@ -1,5 +1,5 @@
 import uuid as uuid_pkg
-from datetime import datetime
+from datetime import datetime, UTC
 
 from sqlalchemy import String, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
@@ -21,7 +21,7 @@ class Post(Base):
     media_url: Mapped[str | None] = mapped_column(String, default=None)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=datetime.utcnow
+        DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
     updated_at: Mapped[datetime | None] = mapped_column(default=None)
     deleted_at: Mapped[datetime | None] = mapped_column(default=None)

--- a/src/app/models/rate_limit.py
+++ b/src/app/models/rate_limit.py
@@ -21,4 +21,4 @@ class RateLimit(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)

--- a/src/app/models/rate_limit.py
+++ b/src/app/models/rate_limit.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, UTC
 
 from sqlalchemy import String, DateTime, ForeignKey, Integer
 from sqlalchemy.orm import Mapped, mapped_column
@@ -19,6 +19,6 @@ class RateLimit(Base):
     period: Mapped[int] = mapped_column(Integer, nullable=False)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=datetime.utcnow
+        DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/app/models/tier.py
+++ b/src/app/models/tier.py
@@ -15,6 +15,6 @@ class Tier(Base):
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=lambda:  datetime.now(UTC).replace(tzinfo=None)
+        DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/app/models/tier.py
+++ b/src/app/models/tier.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from sqlalchemy import String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
@@ -15,6 +15,6 @@ class Tier(Base):
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=lambda:  datetime.now(timezone.utc).replace(tzinfo=None)
+        DateTime, default_factory=lambda:  datetime.now(UTC).replace(tzinfo=None)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/app/models/tier.py
+++ b/src/app/models/tier.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
@@ -15,6 +15,6 @@ class Tier(Base):
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=datetime.utcnow
+        DateTime, default_factory=lambda:  datetime.now(timezone.utc).replace(tzinfo=None)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/app/models/tier.py
+++ b/src/app/models/tier.py
@@ -17,4 +17,4 @@ class Tier(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -24,7 +24,7 @@ class User(Base):
         default_factory=uuid_pkg.uuid4, primary_key=True, unique=True
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=lambda:  datetime.now(UTC).replace(tzinfo=None)
+        DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
     deleted_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -26,8 +26,8 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default_factory=lambda:  datetime.now(UTC)
     )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(default=None)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), default=None)
     is_deleted: Mapped[bool] = mapped_column(default=False, index=True)
     is_superuser: Mapped[bool] = mapped_column(default=False)
 

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import uuid as uuid_pkg
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from sqlalchemy import String, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
@@ -24,7 +24,7 @@ class User(Base):
         default_factory=uuid_pkg.uuid4, primary_key=True, unique=True
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=lambda:  datetime.now(timezone.utc).replace(tzinfo=None)
+        DateTime, default_factory=lambda:  datetime.now(UTC).replace(tzinfo=None)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
     deleted_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -1,6 +1,6 @@
 from typing import Optional
 import uuid as uuid_pkg
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import String, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
@@ -24,7 +24,7 @@ class User(Base):
         default_factory=uuid_pkg.uuid4, primary_key=True, unique=True
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default_factory=datetime.utcnow
+        DateTime, default_factory=lambda:  datetime.now(timezone.utc).replace(tzinfo=None)
     )
     updated_at: Mapped[Optional[datetime]] = mapped_column(default=None)
     deleted_at: Mapped[Optional[datetime]] = mapped_column(default=None)

--- a/src/scripts/create_first_superuser.py
+++ b/src/scripts/create_first_superuser.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ..app.core.db.database import async_engine
 from ..app.core.db.database import AsyncSession, local_session
@@ -42,7 +42,7 @@ async def create_first_user(session: AsyncSession) -> None:
             Column("hashed_password", String, nullable=False),
             Column("profile_image_url", String, default="https://profileimageurl.com"),
             Column("uuid", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True),
-            Column("created_at", DateTime, default=datetime.utcnow, nullable=False),
+            Column("created_at", DateTime, default=lambda:  datetime.now(timezone.utc).replace(tzinfo=None), nullable=False),
             Column("updated_at", DateTime),
             Column("deleted_at", DateTime),
             Column("is_deleted", Boolean, default=False, index=True),

--- a/src/scripts/create_first_superuser.py
+++ b/src/scripts/create_first_superuser.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from ..app.core.db.database import async_engine
 from ..app.core.db.database import AsyncSession, local_session
@@ -42,7 +42,7 @@ async def create_first_user(session: AsyncSession) -> None:
             Column("hashed_password", String, nullable=False),
             Column("profile_image_url", String, default="https://profileimageurl.com"),
             Column("uuid", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True),
-            Column("created_at", DateTime, default=lambda:  datetime.now(timezone.utc).replace(tzinfo=None), nullable=False),
+            Column("created_at", DateTime, default=lambda:  datetime.now(UTC).replace(tzinfo=None), nullable=False),
             Column("updated_at", DateTime),
             Column("deleted_at", DateTime),
             Column("is_deleted", Boolean, default=False, index=True),

--- a/src/scripts/create_first_superuser.py
+++ b/src/scripts/create_first_superuser.py
@@ -42,7 +42,7 @@ async def create_first_user(session: AsyncSession) -> None:
             Column("hashed_password", String, nullable=False),
             Column("profile_image_url", String, default="https://profileimageurl.com"),
             Column("uuid", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True),
-            Column("created_at", DateTime, default=lambda:  datetime.now(UTC).replace(tzinfo=None), nullable=False),
+            Column("created_at", DateTime(timezone=True), default=lambda:  datetime.now(UTC), nullable=False),
             Column("updated_at", DateTime),
             Column("deleted_at", DateTime),
             Column("is_deleted", Boolean, default=False, index=True),


### PR DESCRIPTION
Updated datetime.utcnow() to datetime.now(timezone.utc) in multiple modules and added timezone.utc

Solve this issue:
https://github.com/igorbenav/FastAPI-boilerplate/issues/79 