### PR TITLE
Removed deprecated typing classes and replaced with native Python dict, list, type, etc.

### DIFF
--- a/src/app/api/paginated.py
+++ b/src/app/api/paginated.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, List, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -6,7 +6,7 @@ SchemaType = TypeVar("SchemaType", bound=BaseModel)
 
 
 class ListResponse(BaseModel, Generic[SchemaType]):
-    data: List[SchemaType]
+    data: list[SchemaType]
 
 
 class PaginatedListResponse(ListResponse[SchemaType]):
@@ -16,7 +16,7 @@ class PaginatedListResponse(ListResponse[SchemaType]):
     items_per_page: int | None = None
 
 
-def paginated_response(crud_data: dict, page: int, items_per_page: int) -> Dict[str, Any]:
+def paginated_response(crud_data: dict, page: int, items_per_page: int) -> dict[str, Any]:
     """
     Create a paginated response based on the provided data and pagination parameters.
 
@@ -31,7 +31,7 @@ def paginated_response(crud_data: dict, page: int, items_per_page: int) -> Dict[
 
     Returns
     -------
-    Dict[str, Any]
+    dict[str, Any]
         A structured paginated response dict containing the list of items, total count, pagination flags, and numbers.
 
     Note

--- a/src/app/api/v1/login.py
+++ b/src/app/api/v1/login.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Annotated, Dict
+from typing import Annotated
 
 import fastapi
 from fastapi import Depends, Request, Response
@@ -26,7 +26,7 @@ async def login_for_access_token(
     response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     db: Annotated[AsyncSession, Depends(async_get_db)],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     user = await authenticate_user(username_or_email=form_data.username, password=form_data.password, db=db)
     if not user:
         raise UnauthorizedException("Wrong username, email or password.")
@@ -45,7 +45,7 @@ async def login_for_access_token(
 
 
 @router.post("/refresh")
-async def refresh_access_token(request: Request, db: AsyncSession = Depends(async_get_db)) -> Dict[str, str]:
+async def refresh_access_token(request: Request, db: AsyncSession = Depends(async_get_db)) -> dict[str, str]:
     refresh_token = request.cookies.get("refresh_token")
     if not refresh_token:
         raise UnauthorizedException("Refresh token missing.")

--- a/src/app/api/v1/logout.py
+++ b/src/app/api/v1/logout.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from fastapi import APIRouter, Depends, Response
 from jose import JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,7 +12,7 @@ router = APIRouter(tags=["login"])
 @router.post("/logout")
 async def logout(
     response: Response, access_token: str = Depends(oauth2_scheme), db: AsyncSession = Depends(async_get_db)
-) -> Dict[str, str]:
+) -> dict[str, str]:
     try:
         await blacklist_token(token=access_token, db=db)
         response.delete_cookie(key="refresh_token")

--- a/src/app/api/v1/posts.py
+++ b/src/app/api/v1/posts.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict
+from typing import Annotated
 
 import fastapi
 from fastapi import Depends, Request
@@ -95,7 +95,7 @@ async def patch_post(
     values: PostUpdate,
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise NotFoundException("User not found")
@@ -119,7 +119,7 @@ async def erase_post(
     id: int,
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise NotFoundException("User not found")
@@ -140,7 +140,7 @@ async def erase_post(
 @cache("{username}_post_cache", resource_id_name="id", to_invalidate_extra={"{username}_posts": "{username}"})
 async def erase_db_post(
     request: Request, username: str, id: int, db: Annotated[AsyncSession, Depends(async_get_db)]
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username, is_deleted=False)
     if db_user is None:
         raise NotFoundException("User not found")

--- a/src/app/api/v1/rate_limits.py
+++ b/src/app/api/v1/rate_limits.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict
+from typing import Annotated
 
 import fastapi
 from fastapi import Depends, Request
@@ -79,7 +79,7 @@ async def patch_rate_limit(
     id: int,
     values: RateLimitUpdate,
     db: Annotated[AsyncSession, Depends(async_get_db)],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_tier = await crud_tiers.get(db=db, name=tier_name)
     if db_tier is None:
         raise NotFoundException("Tier not found")
@@ -103,7 +103,7 @@ async def patch_rate_limit(
 @router.delete("/tier/{tier_name}/rate_limit/{id}", dependencies=[Depends(get_current_superuser)])
 async def erase_rate_limit(
     request: Request, tier_name: str, id: int, db: Annotated[AsyncSession, Depends(async_get_db)]
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_tier = await crud_tiers.get(db=db, name=tier_name)
     if not db_tier:
         raise NotFoundException("Tier not found")

--- a/src/app/api/v1/tasks.py
+++ b/src/app/api/v1/tasks.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from arq.jobs import Job as ArqJob
 from fastapi import APIRouter, Depends
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
 @router.post("/task", response_model=Job, status_code=201, dependencies=[Depends(rate_limiter)])
-async def create_task(message: str) -> Dict[str, str]:
+async def create_task(message: str) -> dict[str, str]:
     """
     Create a new background task.
 
@@ -22,7 +22,7 @@ async def create_task(message: str) -> Dict[str, str]:
 
     Returns
     -------
-    Dict[str, str]
+    dict[str, str]
         A dictionary containing the ID of the created task.
     """
     job = await queue.pool.enqueue_job("sample_background_task", message)  # type: ignore
@@ -30,7 +30,7 @@ async def create_task(message: str) -> Dict[str, str]:
 
 
 @router.get("/task/{task_id}")
-async def get_task(task_id: str) -> Optional[Dict[str, Any]]:
+async def get_task(task_id: str) -> Optional[dict[str, Any]]:
     """
     Get information about a specific background task.
 
@@ -41,7 +41,7 @@ async def get_task(task_id: str) -> Optional[Dict[str, Any]]:
 
     Returns
     -------
-    Optional[Dict[str, Any]]
+    Optional[dict[str, Any]]
         A dictionary containing information about the task if found, or None otherwise.
     """
     job = ArqJob(task_id, queue.pool)

--- a/src/app/api/v1/tiers.py
+++ b/src/app/api/v1/tiers.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict
+from typing import Annotated
 
 import fastapi
 from fastapi import Depends, Request
@@ -50,7 +50,7 @@ async def read_tier(request: Request, name: str, db: Annotated[AsyncSession, Dep
 @router.patch("/tier/{name}", dependencies=[Depends(get_current_superuser)])
 async def patch_tier(
     request: Request, values: TierUpdate, name: str, db: Annotated[AsyncSession, Depends(async_get_db)]
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, name=name)
     if db_tier is None:
         raise NotFoundException("Tier not found")
@@ -60,7 +60,7 @@ async def patch_tier(
 
 
 @router.delete("/tier/{name}", dependencies=[Depends(get_current_superuser)])
-async def erase_tier(request: Request, name: str, db: Annotated[AsyncSession, Depends(async_get_db)]) -> Dict[str, str]:
+async def erase_tier(request: Request, name: str, db: Annotated[AsyncSession, Depends(async_get_db)]) -> dict[str, str]:
     db_tier = await crud_tiers.get(db=db, schema_to_select=TierRead, name=name)
     if db_tier is None:
         raise NotFoundException("Tier not found")

--- a/src/app/api/v1/users.py
+++ b/src/app/api/v1/users.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any
 
 import fastapi
 from fastapi import Depends, Request
@@ -75,7 +75,7 @@ async def patch_user(
     username: str,
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username)
     if db_user is None:
         raise NotFoundException("User not found")
@@ -104,7 +104,7 @@ async def erase_user(
     current_user: Annotated[UserRead, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(async_get_db)],
     token: str = Depends(oauth2_scheme),
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.get(db=db, schema_to_select=UserRead, username=username)
     if not db_user:
         raise NotFoundException("User not found")
@@ -123,7 +123,7 @@ async def erase_db_user(
     username: str,
     db: Annotated[AsyncSession, Depends(async_get_db)],
     token: str = Depends(oauth2_scheme),
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.exists(db=db, username=username)
     if not db_user:
         raise NotFoundException("User not found")
@@ -136,7 +136,7 @@ async def erase_db_user(
 @router.get("/user/{username}/rate_limits", dependencies=[Depends(get_current_superuser)])
 async def read_user_rate_limits(
     request: Request, username: str, db: Annotated[AsyncSession, Depends(async_get_db)]
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     db_user: dict | None = await crud_users.get(db=db, username=username, schema_to_select=UserRead)
     if db_user is None:
         raise NotFoundException("User not found")
@@ -183,7 +183,7 @@ async def read_user_tier(
 @router.patch("/user/{username}/tier", dependencies=[Depends(get_current_superuser)])
 async def patch_user_tier(
     request: Request, username: str, values: UserTierUpdate, db: Annotated[AsyncSession, Depends(async_get_db)]
-) -> Dict[str, str]:
+) -> dict[str, str]:
     db_user = await crud_users.get(db=db, username=username, schema_to_select=UserRead)
     if db_user is None:
         raise NotFoundException("User not found")

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime, timedelta
-from typing import Any, Dict, Literal, Union
+from typing import Any, Literal, Union
 
 import bcrypt
 from fastapi.security import OAuth2PasswordBearer
@@ -31,7 +31,7 @@ def get_password_hash(password: str) -> str:
 
 async def authenticate_user(
     username_or_email: str, password: str, db: AsyncSession
-) -> Union[Dict[str, Any], Literal[False]]:
+) -> Union[dict[str, Any], Literal[False]]:
     if "@" in username_or_email:
         db_user: dict | None = await crud_users.get(db=db, email=username_or_email, is_deleted=False)
     else:

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 import anyio
 import fastapi
@@ -176,7 +176,7 @@ def create_application(
                 return get_redoc_html(openapi_url="/openapi.json", title="docs")
 
             @docs_router.get("/openapi.json", include_in_schema=False)
-            async def openapi() -> Dict[str, Any]:
+            async def openapi() -> dict[str, Any]:
                 out: dict = get_openapi(title=application.title, version=application.version, routes=application.routes)
                 return out
 

--- a/src/app/core/utils/cache.py
+++ b/src/app/core/utils/cache.py
@@ -2,7 +2,7 @@ import functools
 import json
 import re
 from collections.abc import Callable
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Union
 
 from fastapi import Request, Response
 from fastapi.encoders import jsonable_encoder
@@ -14,7 +14,7 @@ pool: ConnectionPool | None = None
 client: Redis | None = None
 
 
-def _infer_resource_id(kwargs: Dict[str, Any], resource_id_type: Union[type, Tuple[type, ...]]) -> int | str:
+def _infer_resource_id(kwargs: dict[str, Any], resource_id_type: Union[type, tuple[type, ...]]) -> int | str:
     """
     Infer the resource ID from a dictionary of keyword arguments.
 
@@ -53,7 +53,7 @@ def _infer_resource_id(kwargs: Dict[str, Any], resource_id_type: Union[type, Tup
     return resource_id
 
 
-def _extract_data_inside_brackets(input_string: str) -> List[str]:
+def _extract_data_inside_brackets(input_string: str) -> list[str]:
     """
     Extract data inside curly brackets from a given string using regular expressions.
 
@@ -76,7 +76,7 @@ def _extract_data_inside_brackets(input_string: str) -> List[str]:
     return data_inside_brackets
 
 
-def _construct_data_dict(data_inside_brackets: List[str], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def _construct_data_dict(data_inside_brackets: list[str], kwargs: dict[str, Any]) -> dict[str, Any]:
     """
     Construct a dictionary based on data inside brackets and keyword arguments.
 
@@ -97,7 +97,7 @@ def _construct_data_dict(data_inside_brackets: List[str], kwargs: Dict[str, Any]
     return data_dict
 
 
-def _format_prefix(prefix: str, kwargs: Dict[str, Any]) -> str:
+def _format_prefix(prefix: str, kwargs: dict[str, Any]) -> str:
     """
     Format a prefix using keyword arguments.
 
@@ -118,7 +118,7 @@ def _format_prefix(prefix: str, kwargs: Dict[str, Any]) -> str:
     return formatted_prefix
 
 
-def _format_extra_data(to_invalidate_extra: Dict[str, str], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def _format_extra_data(to_invalidate_extra: dict[str, str], kwargs: dict[str, Any]) -> dict[str, Any]:
     """
     Format extra data based on provided templates and keyword arguments.
 
@@ -191,9 +191,9 @@ def cache(
     key_prefix: str,
     resource_id_name: Any = None,
     expiration: int = 3600,
-    resource_id_type: Union[type, Tuple[type, ...]] = int,
-    to_invalidate_extra: Dict[str, Any] | None = None,
-    pattern_to_invalidate_extra: List[str] | None = None,
+    resource_id_type: Union[type, tuple[type, ...]] = int,
+    to_invalidate_extra: dict[str, Any] | None = None,
+    pattern_to_invalidate_extra: list[str] | None = None,
 ) -> Callable:
     """
     Cache decorator for FastAPI endpoints.

--- a/src/app/crud/crud_base.py
+++ b/src/app/crud/crud_base.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from typing import Any, Dict, Generic, List, Type, TypeVar, Union
+from typing import Any, Generic, TypeVar, Union
 
 from pydantic import BaseModel
 from sqlalchemy import and_, delete, func, inspect, select, update
@@ -32,7 +32,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         The SQLAlchemy model type.
     """
 
-    def __init__(self, model: Type[ModelType]) -> None:
+    def __init__(self, model: type[ModelType]) -> None:
         self._model = model
 
     async def create(self, db: AsyncSession, object: CreateSchemaType) -> ModelType:
@@ -58,8 +58,8 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         return db_object
 
     async def get(
-        self, db: AsyncSession, schema_to_select: Union[Type[BaseModel], List, None] = None, **kwargs: Any
-    ) -> Dict | None:
+        self, db: AsyncSession, schema_to_select: Union[type[BaseModel], list, None] = None, **kwargs: Any
+    ) -> dict | None:
         """
         Fetch a single record based on filters.
 
@@ -67,14 +67,14 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         ----------
         db : AsyncSession
             The SQLAlchemy async session.
-        schema_to_select : Union[Type[BaseModel], List, None], optional
+        schema_to_select : Union[Type[BaseModel], list, None], optional
             Pydantic schema for selecting specific columns. Default is None to select all columns.
         kwargs : dict
             Filters to apply to the query.
 
         Returns
         -------
-        Dict | None
+        dict | None
             The fetched database row or None if not found.
         """
         to_select = _extract_matching_columns_from_schema(model=self._model, schema=schema_to_select)
@@ -146,9 +146,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         db: AsyncSession,
         offset: int = 0,
         limit: int = 100,
-        schema_to_select: Union[Type[BaseModel], List[Type[BaseModel]], None] = None,
+        schema_to_select: Union[type[BaseModel], list[type[BaseModel]], None] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Fetch multiple records based on filters.
 
@@ -160,14 +160,14 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
             Number of rows to skip before fetching. Default is 0.
         limit : int, optional
             Maximum number of rows to fetch. Default is 100.
-        schema_to_select : Union[Type[BaseModel], List[Type[BaseModel]], None], optional
+        schema_to_select : Union[Type[BaseModel], list[Type[BaseModel]], None], optional
             Pydantic schema for selecting specific columns. Default is None to select all columns.
         kwargs : dict
             Filters to apply to the query.
 
         Returns
         -------
-        Dict[str, Any]
+        dict[str, Any]
             Dictionary containing the fetched rows under 'data' key and total count under 'total_count'.
         """
         to_select = _extract_matching_columns_from_schema(model=self._model, schema=schema_to_select)
@@ -183,11 +183,11 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
     async def get_joined(
         self,
         db: AsyncSession,
-        join_model: Type[ModelType],
+        join_model: type[ModelType],
         join_prefix: str | None = None,
         join_on: Union[Join, None] = None,
-        schema_to_select: Union[Type[BaseModel], List, None] = None,
-        join_schema_to_select: Union[Type[BaseModel], List, None] = None,
+        schema_to_select: Union[type[BaseModel], list, None] = None,
+        join_schema_to_select: Union[type[BaseModel], list, None] = None,
         join_type: str = "left",
         **kwargs: Any,
     ) -> dict | None:
@@ -206,9 +206,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         join_on : Join, optional
             SQLAlchemy Join object for specifying the ON clause of the join. If None, the join condition is
             auto-detected based on foreign keys.
-        schema_to_select : Union[Type[BaseModel], List, None], optional
+        schema_to_select : Union[Type[BaseModel], list, None], optional
             Pydantic schema for selecting specific columns from the primary model.
-        join_schema_to_select : Union[Type[BaseModel], List, None], optional
+        join_schema_to_select : Union[Type[BaseModel], list, None], optional
             Pydantic schema for selecting specific columns from the joined model.
         join_type : str, default "left"
             Specifies the type of join operation to perform. Can be "left" for a left outer join
@@ -218,7 +218,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
 
         Returns
         -------
-        Dict | None
+        dict | None
             The fetched database row or None if not found.
 
         Examples
@@ -307,16 +307,16 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
     async def get_multi_joined(
         self,
         db: AsyncSession,
-        join_model: Type[ModelType],
+        join_model: type[ModelType],
         join_prefix: str | None = None,
         join_on: Union[Join, None] = None,
-        schema_to_select: Union[Type[BaseModel], List[Type[BaseModel]], None] = None,
-        join_schema_to_select: Union[Type[BaseModel], List[Type[BaseModel]], None] = None,
+        schema_to_select: Union[type[BaseModel], list[type[BaseModel]], None] = None,
+        join_schema_to_select: Union[type[BaseModel], list[type[BaseModel]], None] = None,
         join_type: str = "left",
         offset: int = 0,
         limit: int = 100,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Fetch multiple records with a join on another model, allowing for pagination.
 
@@ -331,9 +331,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         join_on : Join, optional
             SQLAlchemy Join object for specifying the ON clause of the join. If None, the join condition is
             auto-detected based on foreign keys.
-        schema_to_select : Union[Type[BaseModel], List[Type[BaseModel]], None], optional
+        schema_to_select : Union[Type[BaseModel], list[Type[BaseModel]], None], optional
             Pydantic schema for selecting specific columns from the primary model.
-        join_schema_to_select : Union[Type[BaseModel], List[Type[BaseModel]], None], optional
+        join_schema_to_select : Union[Type[BaseModel], list[Type[BaseModel]], None], optional
             Pydantic schema for selecting specific columns from the joined model.
         join_type : str, default "left"
             Specifies the type of join operation to perform. Can be "left" for a left outer join
@@ -347,7 +347,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
 
         Returns
         -------
-        Dict[str, Any]
+        dict[str, Any]
             A dictionary containing the fetched rows under 'data' key and total count under 'total_count'.
 
         Examples
@@ -399,7 +399,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
 
         return {"data": data, "total_count": total_count}
 
-    async def update(self, db: AsyncSession, object: Union[UpdateSchemaType, Dict[str, Any]], **kwargs: Any) -> None:
+    async def update(self, db: AsyncSession, object: Union[UpdateSchemaType, dict[str, Any]], **kwargs: Any) -> None:
         """
         Update an existing record in the database.
 
@@ -407,7 +407,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType, UpdateSche
         ----------
         db : AsyncSession
             The SQLAlchemy async session.
-        object : Union[UpdateSchemaType, Dict[str, Any]]
+        object : Union[UpdateSchemaType, dict[str, Any]]
             The Pydantic schema or dictionary containing the data to be updated.
         kwargs : dict
             Filters for the update.

--- a/src/app/crud/helper.py
+++ b/src/app/crud/helper.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel
 from sqlalchemy import inspect
@@ -10,7 +10,7 @@ from sqlalchemy.sql.schema import Column
 from ..core.db.database import Base
 
 
-def _extract_matching_columns_from_schema(model: Type[Base], schema: Union[Type[BaseModel], list, None]) -> List[Any]:
+def _extract_matching_columns_from_schema(model: type[Base], schema: Union[type[BaseModel], list, None]) -> list[Any]:
     """
     Retrieves a list of ORM column objects from a SQLAlchemy model that match the
     field names in a given Pydantic schema.
@@ -24,7 +24,7 @@ def _extract_matching_columns_from_schema(model: Type[Base], schema: Union[Type[
 
     Returns
     -------
-    List[Any]
+    list[Any]
         A list of ORM column objects from the model that correspond to the field names defined in the schema.
     """
     column_list = list(model.__table__.columns)
@@ -42,7 +42,7 @@ def _extract_matching_columns_from_schema(model: Type[Base], schema: Union[Type[
     return column_list
 
 
-def _extract_matching_columns_from_kwargs(model: Type[Base], kwargs: dict) -> List[Any]:
+def _extract_matching_columns_from_kwargs(model: type[Base], kwargs: dict) -> list[Any]:
     if kwargs is not None:
         kwargs_fields = kwargs.keys()
         column_list = []
@@ -53,7 +53,7 @@ def _extract_matching_columns_from_kwargs(model: Type[Base], kwargs: dict) -> Li
     return column_list
 
 
-def _extract_matching_columns_from_column_names(model: Type[Base], column_names: list) -> List[Any]:
+def _extract_matching_columns_from_column_names(model: type[Base], column_names: list) -> list[Any]:
     column_list = []
     for column_name in column_names:
         if hasattr(model, column_name):
@@ -63,7 +63,7 @@ def _extract_matching_columns_from_column_names(model: Type[Base], column_names:
 
 
 def _auto_detect_join_condition(
-    base_model: Type[DeclarativeMeta], join_model: Type[DeclarativeMeta]
+    base_model: type[DeclarativeMeta], join_model: type[DeclarativeMeta]
 ) -> Optional[ColumnElement]:
     """
     Automatically detects the join condition for SQLAlchemy models based on foreign key relationships.


### PR DESCRIPTION
Created as a fix for issue #89. Scanning the repository with `ruff check` no longer results in deprecated errors.