### PR TITLE
Update ARQ Job Queues documentation and add database session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,9 +1256,9 @@ For `client-side caching`, all you have to do is let the `Settings` class define
 
 ### 5.10 ARQ Job Queues
 
-Depending on the problem your API is solving, you might want to implement a job queue. A job queue allows you to run tasks in the background, and usually is made for functions that require longer run times and don't directly impact user response. As a rule of thumb, if a tasks requires more than 2 seconds to be run, can be run in an async way and its result is not needed for the next step of the user's interaction, then it is a good candidate to be ran in the job queue.
+Depending on the problem your API is solving, you might want to implement a job queue. A job queue allows you to run tasks in the background, and is usually aimed at functions that require longer run times and don't directly impact user response in your frontend. As a rule of thumb, if a task takes more than 2 seconds to run, can be executed asynchronously, and its result is not needed for the next step of the user's interaction, then it is a good candidate for the job queue.
 
-> A very common candidate for job queues/ background functions are calls to and from LLM endpoints (e.g. OpenAI or Openrouter). This is because they span tens of seconds and often need to be further parsed and saved.
+> Very common candidates for background functions are calls to and from LLM endpoints (e.g. OpenAI or Openrouter). This is because they span tens of seconds and often need to be further parsed and saved.
 
 #### Background task creation
 
@@ -1310,7 +1310,7 @@ If you are doing it from scratch, run while in the `root` folder:
 poetry run arq src.app.core.worker.settings.WorkerSettings
 ```
 
-#### Database sessions with background tasks
+#### Database session with background tasks
 
 With time your background functions will become 'workflows' increasing in complexity and requirements. Probably, you will need to use a database session to get, create, update, or delete data as part of this workflow.
 

--- a/README.md
+++ b/README.md
@@ -535,8 +535,7 @@ And to apply the migration
 poetry run alembic upgrade head
 ```
 
-\[!NOTE\]
-
+> [!NOTE]
 > If you do not have poetry, you may run it without poetry after running `pip install alembic`
 
 ## 5. Extending
@@ -1258,6 +1257,7 @@ For `client-side caching`, all you have to do is let the `Settings` class define
 
 Depending on the problem your API is solving, you might want to implement a job queue. A job queue allows you to run tasks in the background, and is usually aimed at functions that require longer run times and don't directly impact user response in your frontend. As a rule of thumb, if a task takes more than 2 seconds to run, can be executed asynchronously, and its result is not needed for the next step of the user's interaction, then it is a good candidate for the job queue.
 
+> [!TIP]
 > Very common candidates for background functions are calls to and from LLM endpoints (e.g. OpenAI or Openrouter). This is because they span tens of seconds and often need to be further parsed and saved.
 
 #### Background task creation
@@ -1300,7 +1300,7 @@ async def get_task(task_id: str):
 
 And finally run the worker in parallel to your fastapi application.
 
-> \[!CAUTION\]
+> [!IMPORTANT]
 > For any change to the `sample_background_task` to be reflected in the worker, you need to restart the worker (e.g. the docker container).
 
 If you are using `docker compose`, the worker is already running.
@@ -1345,7 +1345,7 @@ async def your_background_function(
     ...
 ```
 
-> \[!CAUTION\]
+> [!WARNING]
 > When using database sessions, you will want to use Pydantic objects. However, these objects don't mingle well with the seralization required by ARQ tasks and will be retrieved as a dictionary.
 
 ### 5.11 Rate Limiting


### PR DESCRIPTION
As discussed with @igorbenav, this PR closes #138.

I took the freedom to marginally expand the documentation and rationale of using ARQ Job Queues and added a small h4 section on dealing with a database session.

On a semi-related note, another aspect we could futher explore is dealing with Pydantic objects in these tasks, as ARQ does not deal with them correctly due to serialization. Some approaches require you to cast them back to Pydantic (`your_object = YourObjectPydanticClass(**your_object_dict_from_db)` some just deal with them as dictionaries. Might be useful to point users to a best practice?

On a less-related note, @igorbenav I'd love to contribute more and have some ideas to improve the project I'd like to explore. Feel free to drop me a note using my email on my profile.