### PR TITLE
Fixes default expire time in creating access token

### DIFF
--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -49,7 +49,7 @@ async def create_access_token(data: dict[str, Any], expires_delta: timedelta | N
     if expires_delta:
         expire = datetime.now(UTC).replace(tzinfo=None) + expires_delta
     else:
-        expire = datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=15)
+        expire = datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
     encoded_jwt: str = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt


### PR DESCRIPTION
Fixes the default expire timedelta used in the function to create an access token.

The default timedelta in create_access_token is updated from '15' to the config setting of ACCESS_TOKEN_EXPIRE_MINUTES.

This matches the behavior of the create_refresh_token function right below it, which uses the config setting of REFRESH_TOKEN_EXPIRE_DAYS for its default expire timedelta. (ACCESS_TOKEN_EXPIRE_MINUTES was also already imported into the file for this likely purpose while not being used.)