### PR TITLE
Update Dockerfile to install additional Poetry plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11 as requirements-stage
 
 WORKDIR /tmp
 
-RUN pip install poetry
+RUN pip install poetry poetry-plugin-export
 
 COPY ./pyproject.toml ./poetry.lock* /tmp/
 


### PR DESCRIPTION
This pull request updates the Dockerfile to add the Poetry export plugin, required for Poetry 2.0 as it no longer installs the plugin by default.

For details: [Poetry  Docs](https://python-poetry.org/docs/cli#export)