### PR TITLE
Update pre-commit hooks version to solve InvalidManifestError

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -25,7 +25,7 @@ repos:
         name: Upgrade code to Python 3.10+
 
   - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+    rev: v1.7.7
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]


### PR DESCRIPTION
The current pre-commit config is broken, yielding the following error when tryogn to run it:

```bash
INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[WARNING] repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
[INFO] Initializing environment for https://github.com/myint/docformatter.
An error has occurred: InvalidManifestError: 
==> File /Users/rragundez/.cache/pre-commit/repoq1s4c74o/.pre-commit-hooks.yaml
==> At Hook(id='docformatter-venv')
==> At key: language
=====> Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, julia, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv'
Check the log at /Users/rragundez/.cache/pre-commit/pre-commit.log
```
This PR updated the version which solves the `InvalidManifestError`

