### PR TITLE
Update python specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A fully Async FastAPI boilerplate using SQLAlchemy and Pydantic 2
 authors = [{ name = "Igor Magalhaes", email = "igor.magalhaes.r@gmail.com" }]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = "~=3.11"
+requires-python = ">=3.11, <4"
 dependencies = [
     "python-dotenv>=1.0.0",
     "pydantic[email]>=2.6.1",


### PR DESCRIPTION
Update python specifier to follow best practices, be explicit and remove warning

At the moment the python version is specified as follows: 

requires-python = "~=3.11"

Even though quite compact it suffers from implicitness that can lead to bugs later one. The warning from uv explains it better:

> warning: The `requires-python` specifier (`~=3.11`) in `fastapi-boilerplate` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.11, <4`. Did you mean `~=3.11.0` to constrain the version as `>=3.11.0, <3.12`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.


Instead is better to be explicit. This PR changes the version specific to be explicit which also removes the waning from uv.