### PR TITLE
Adding note on exceptions.md about falsy values possibly coming from FastCRUD in the future.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ cython_debug/
 .ruff_cache
 
 .idea
+
+.vscode/

--- a/docs/user-guide/api/exceptions.md
+++ b/docs/user-guide/api/exceptions.md
@@ -63,7 +63,7 @@ from app.core.exceptions.http_exceptions import ForbiddenException
 async def delete_user(
     user_id: int,
     current_user: Annotated[dict, Depends(get_current_user)]
-):
+        ):
     if current_user["id"] != user_id and not current_user["is_superuser"]:
         raise ForbiddenException("You can only delete your own account")
     
@@ -121,7 +121,7 @@ async def update_user(
     user_id: int,
     user_data: UserUpdate,
     db: AsyncSession
-):
+        ):
     # Check if user exists
     if not await crud_users.exists(db=db, id=user_id):
         raise NotFoundException("User not found")
@@ -143,7 +143,7 @@ async def get_post(
     post_id: int,
     current_user: Annotated[dict, Depends(get_current_user)],
     db: AsyncSession
-):
+        ):
     post = await crud_posts.get(db=db, id=post_id)
     if not post:
         raise NotFoundException("Post not found")
@@ -154,6 +154,10 @@ async def get_post(
     
     return post
 ```
+
+> **Note:**  
+> Some CRUD helper functions may evolve to return falsy-but-valid values (e.g. empty objects).  
+> To future-proof your API, prefer `if post is None:` instead of `if not post:` when checking existence.
 
 ## Validation Errors
 


### PR DESCRIPTION
Addresing point 8 of [this issue](https://github.com/benavlabs/FastAPI-boilerplate/issues/195)