### PR TITLE
Fix duplicated loading of environment variables when collecting settings

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -17,7 +17,7 @@ Open `src/.env` and set these required values:
 ### Application Settings
 
 ```env
-# App Settings  
+# App Settings
 APP_NAME="Your app name here"
 APP_DESCRIPTION="Your app description here"
 APP_VERSION="0.1"
@@ -49,9 +49,10 @@ PGADMIN_LISTEN_PORT=80
 ```
 
 **To connect to database in PGAdmin:**
+
 1. Login with `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD`
-2. Click "Add Server"
-3. Use these connection settings:
+1. Click "Add Server"
+1. Use these connection settings:
    - **Hostname/address**: `db` (if using containers) or `localhost`
    - **Port**: Value from `POSTGRES_PORT`
    - **Database**: `postgres` (leave as default)
@@ -96,7 +97,7 @@ REDIS_CACHE_PORT=6379
 CLIENT_CACHE_MAX_AGE=30          # Default: 30 seconds
 
 # Redis Job Queue
-REDIS_QUEUE_HOST="localhost"     # Use "redis" for Docker Compose  
+REDIS_QUEUE_HOST="localhost"     # Use "redis" for Docker Compose
 REDIS_QUEUE_PORT=6379
 
 # Redis Rate Limiting
@@ -105,7 +106,7 @@ REDIS_RATE_LIMIT_PORT=6379
 ```
 
 !!! warning "Redis in Production"
-    You may use the same Redis instance for caching and queues while developing, but use separate containers in production.
+You may use the same Redis instance for caching and queues while developing, but use separate containers in production.
 
 ### Rate Limiting Defaults
 
@@ -121,18 +122,14 @@ Configure Cross-Origin Resource Sharing for your frontend:
 
 ```env
 # CORS Settings
-CORS_ORIGINS="*"                         # Comma-separated origins (use specific domains in production)
-CORS_METHODS="*"                         # Comma-separated HTTP methods or "*" for all
-CORS_HEADERS="*"                         # Comma-separated headers or "*" for all
+CORS_ORIGINS=["*"]                         # Comma-separated origins (use specific domains in production)
+CORS_METHODS=["*"]                         # Comma-separated HTTP methods or "*" for all
+CORS_HEADERS=["*"]                         # Comma-separated headers or "*" for all
 ```
 
 !!! warning "CORS in Production"
-    Never use `"*"` for CORS_ORIGINS in production. Specify exact domains:
-    ```env
-    CORS_ORIGINS="https://yourapp.com,https://www.yourapp.com"
-    CORS_METHODS="GET,POST,PUT,DELETE,PATCH"
-    CORS_HEADERS="Authorization,Content-Type"
-    ```
+Never use `"*"` for CORS_ORIGINS in production. Specify exact domains:
+`env     CORS_ORIGINS=["https://yourapp.com","https://www.yourapp.com"]     CORS_METHODS=["GET","POST","PUT","DELETE","PATCH"]     CORS_HEADERS=["Authorization","Content-Type"]     `
 
 ### First Tier
 
@@ -170,7 +167,7 @@ REDIS_RATE_LIMIT_HOST="redis"
 The boilerplate includes Redis for caching, job queues, and rate limiting. If running locally without Docker, either:
 
 1. **Install Redis** and keep the default settings
-2. **Disable Redis services** (see [User Guide - Configuration](../user-guide/configuration/index.md) for details)
+1. **Disable Redis services** (see [User Guide - Configuration](../user-guide/configuration/index.md) for details)
 
 ## That's It!
 
@@ -179,4 +176,4 @@ With these basic settings configured, you can start the application:
 - **Docker Compose**: `docker compose up`
 - **Manual**: `uv run uvicorn src.app.main:app --reload`
 
-For detailed configuration options, advanced settings, and production deployment, see the [User Guide - Configuration](../user-guide/configuration/index.md). 
+For detailed configuration options, advanced settings, and production deployment, see the [User Guide - Configuration](../user-guide/configuration/index.md).

--- a/docs/user-guide/authentication/jwt-tokens.md
+++ b/docs/user-guide/authentication/jwt-tokens.md
@@ -518,7 +518,7 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Security Headers
 SECURE_COOKIES=true
-CORS_ORIGINS="http://localhost:3000,https://yourapp.com"
+CORS_ORIGINS=["http://localhost:3000","https://yourapp.com"]
 ```
 
 ### Security Configuration

--- a/docs/user-guide/configuration/environment-specific.md
+++ b/docs/user-guide/configuration/environment-specific.md
@@ -148,8 +148,8 @@ SECRET_KEY="staging-secret-key-different-from-production"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 REFRESH_TOKEN_EXPIRE_DAYS=7
-CORS_ORIGINS="https://staging.example.com"
-CORS_METHODS="GET,POST,PUT,DELETE"
+CORS_ORIGINS=["https://staging.example.com"]
+CORS_METHODS=["GET","POST","PUT","DELETE"]
 
 # ------------- redis -------------
 REDIS_CACHE_HOST="staging-redis.example.com"
@@ -259,9 +259,9 @@ SECRET_KEY="ultra-secure-production-key-generated-with-openssl-rand-hex-32"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES=15  # Shorter for security
 REFRESH_TOKEN_EXPIRE_DAYS=3     # Shorter for security
-CORS_ORIGINS="https://example.com,https://www.example.com"
-CORS_METHODS="GET,POST,PUT,DELETE"
-CORS_HEADERS="Authorization,Content-Type"
+CORS_ORIGINS=["https://example.com","https://www.example.com"]
+CORS_METHODS=["GET","POST","PUT","DELETE"]
+CORS_HEADERS=["Authorization","Content-Type"]
 
 # ------------- redis -------------
 REDIS_CACHE_HOST="prod-redis.example.com"

--- a/docs/user-guide/configuration/environment-variables.md
+++ b/docs/user-guide/configuration/environment-variables.md
@@ -178,33 +178,33 @@ Cross-Origin Resource Sharing (CORS) settings for frontend integration:
 
 ```env
 # ------------- CORS -------------
-CORS_ORIGINS="*"
-CORS_METHODS="*"
-CORS_HEADERS="*"
+CORS_ORIGINS=["*"]
+CORS_METHODS=["*"]
+CORS_HEADERS=["*"]
 ```
 
 **Variables Explained:**
 
-- `CORS_ORIGINS`: Comma-separated list of allowed origins (e.g., `"https://app.com,https://www.app.com"`)
-- `CORS_METHODS`: Comma-separated list of allowed HTTP methods (e.g., `"GET,POST,PUT,DELETE"`)
-- `CORS_HEADERS`: Comma-separated list of allowed headers (e.g., `"Authorization,Content-Type"`)
+- `CORS_ORIGINS`: Comma-separated list of allowed origins (e.g., `["https://app.com","https://www.app.com"]`)
+- `CORS_METHODS`: Comma-separated list of allowed HTTP methods (e.g., `["GET","POST","PUT","DELETE"]`)
+- `CORS_HEADERS`: Comma-separated list of allowed headers (e.g., `["Authorization","Content-Type"]`)
 
 **Environment-Specific Values:**
 
 ```env
 # Development - Allow all origins
-CORS_ORIGINS="*"
-CORS_METHODS="*"
-CORS_HEADERS="*"
+CORS_ORIGINS=["*"]
+CORS_METHODS=["*"]
+CORS_HEADERS=["*"]
 
 # Production - Specific domains only
-CORS_ORIGINS="https://yourapp.com,https://www.yourapp.com"
-CORS_METHODS="GET,POST,PUT,DELETE,PATCH"
-CORS_HEADERS="Authorization,Content-Type,X-Requested-With"
+CORS_ORIGINS=["https://yourapp.com","https://www.yourapp.com"]
+CORS_METHODS=["GET","POST","PUT","DELETE","PATCH"]
+CORS_HEADERS=["Authorization","Content-Type","X-Requested-With"]
 ```
 
 !!! danger "Security Warning"
-    Never use wildcard (`*`) for `CORS_ORIGINS` in production environments. Always specify exact allowed domains to prevent unauthorized cross-origin requests.
+Never use wildcard (`*`) for `CORS_ORIGINS` in production environments. Always specify exact allowed domains to prevent unauthorized cross-origin requests.
 
 ### User Tiers
 

--- a/scripts/local_with_uvicorn/.env.example
+++ b/scripts/local_with_uvicorn/.env.example
@@ -20,7 +20,7 @@ CONTACT_NAME="Me"
 CONTACT_EMAIL="my.email@example.com"
 LICENSE_NAME="MIT"
 
-# ------------- database ------------- 
+# ------------- database -------------
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD=1234
 POSTGRES_SERVER="db"
@@ -55,9 +55,9 @@ REDIS_RATE_LIMIT_PORT=6379
 CLIENT_CACHE_MAX_AGE=60
 
 # ------------- CORS -------------
-CORS_ORIGINS="*"
-CORS_METHODS="*"
-CORS_HEADERS="*"
+CORS_ORIGINS=["*"]
+CORS_METHODS=["*"]
+CORS_HEADERS=["*"]
 
 # ------------- test -------------
 TEST_NAME="Tester User"

--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -1,14 +1,8 @@
 import os
 from enum import Enum
 
-from pydantic import SecretStr, computed_field, field_validator
+from pydantic import SecretStr, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-
-def str_to_list(value: str) -> list[str]:
-    if isinstance(value, str):
-        return [item.strip() for item in value.split(",") if item.strip()]
-    raise ValueError("Invalid string setting for list conversion.")
 
 
 class AppSettings(BaseSettings):
@@ -150,11 +144,9 @@ class EnvironmentSettings(BaseSettings):
 
 
 class CORSSettings(BaseSettings):
-    CORS_ORIGINS: list[str] | str = "*"
-    CORS_METHODS: list[str] | str = "*"
-    CORS_HEADERS: list[str] | str = "*"
-
-    _normalize_to_list = field_validator("CORS_ORIGINS", "CORS_METHODS", "CORS_HEADERS", mode="before")(str_to_list)
+    CORS_ORIGINS: list[str] = ["*"]
+    CORS_METHODS: list[str] = ["*"]
+    CORS_HEADERS: list[str] = ["*"]
 
 
 class Settings(


### PR DESCRIPTION
There are several potential bugs on the current way of loading of settings via environment variables and .env files, mainly caused by a misconfiguration where both, the `pydantic` way and the `starlette` way of loading the settings are being used. 
This can create quite obfuscated bugs as each one has its own logic and loading time (at import and/or at instantiation). I think the reason why it has not presented itself in a big way in the current form of the code is because all settings have a primitive type (even though it fails now for composite settings where the setting retains the default values and not the ones in the .env file e.g. the databases uris). 

It's quite cumbersome to explain every scenario that breaks but in a nutshell there is a lack of consistency. The starlette way loads at import time, it does define the path to the .env file but it prioritizes loading from environment variables. In addition, the pydantic way loads both at import time and instantiation time, at instantiation time it does it from environment variables and it will override any values set by the starlette way at import time. To top it up, the docker compose definition adds the .env file both as environment variables and as an .env file that starlette loads into config. 

This is the first PR of several that will try to correct and simplify how settings are being loaded from environment variables or .env files, and to simplify the documentation. Also at the moment it seems the repository promotes the idea of making an .env file part of the src code and using an .env file in staging or production, which both are not a good practice. 

In particular this PR at the moment removes the loading of duplicated settings coming from starlette and pydantic, and applies only the pydantic best practice. This means that composite settings cannot be formed during import time as it is now but they have to be computed, if not they would pick up the default value only, regardless if an environment variable was set. 
In addition, it starts aligning with the idea that regardless if coming from environment variables directly or from and .env file, settings will always be loaded from environment variables when running the application, therefore separating both tasks ( setting env variables and loading settings)