### PR TITLE
Remove unused sqlite and mysql settings

### DIFF
--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -31,9 +31,7 @@ class PostgresSettings(DatabaseSettings):
     POSTGRES_SERVER: str = "localhost"
     POSTGRES_PORT: int = 5432
     POSTGRES_DB: str = "postgres"
-    POSTGRES_SYNC_PREFIX: str = "postgresql://"
     POSTGRES_ASYNC_PREFIX: str = "postgresql+asyncpg://"
-    POSTGRES_URL: str | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -41,6 +39,11 @@ class PostgresSettings(DatabaseSettings):
         credentials = f"{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}"
         location = f"{self.POSTGRES_SERVER}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"
         return f"{credentials}@{location}"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def POSTGRES_URL(self) -> str:
+        return f"{self.POSTGRES_ASYNC_PREFIX}{self.POSTGRES_URI}"
 
 
 class FirstUserSettings(BaseSettings):

--- a/src/app/core/db/database.py
+++ b/src/app/core/db/database.py
@@ -11,9 +11,7 @@ class Base(DeclarativeBase, MappedAsDataclass):
     pass
 
 
-DATABASE_URI = settings.POSTGRES_URI
-DATABASE_PREFIX = settings.POSTGRES_ASYNC_PREFIX
-DATABASE_URL = f"{DATABASE_PREFIX}{DATABASE_URI}"
+DATABASE_URL = settings.POSTGRES_URL
 
 
 async_engine = create_async_engine(DATABASE_URL, echo=False, future=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,10 @@ from sqlalchemy.orm.session import Session
 from src.app.core.config import settings
 from src.app.main import app
 
-DATABASE_URI = settings.POSTGRES_URI
-DATABASE_PREFIX = settings.POSTGRES_SYNC_PREFIX
+DATABASE_URL = settings.POSTGRES_URL
 
-sync_engine = create_engine(DATABASE_PREFIX + DATABASE_URI)
+
+sync_engine = create_engine(DATABASE_URL)
 local_session = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
 
 


### PR DESCRIPTION
At the moment in the source code there are settings for mysql and sqlite, they are not used anywhere and also not mentioned in any part of the documentation, while the fact they are in the settings hints to the user that they would just work, at least that is how I would understand it if I see them already in the settings. 

This PR removes the dead piece of code which can be confusing to a user. In addition it centralize the creation of the URL connection string in the code base